### PR TITLE
[feat] : 응답 구조 통일 & 전역 에러 처리 & Swagger를 추가한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.2'
+    id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.7'
+
+    // REST Docs
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id 'com.epages.restdocs-api-spec' version '0.19.2'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'com.rcgc'
@@ -24,16 +29,84 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // WEB
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // REST Docs & Swagger
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+}
+
+// REST Docs & Swagger 설정
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+sourceSets {
+    test {
+        java {
+            srcDirs = ['src/test/java']
+        }
+    }
+}
+
+def serverUrl = "http://localhost:8085"
+
+openapi3 {
+    server = serverUrl
+    title = "ILLDAN API Documentation"
+    description = "Spring REST Docs with Swagger UI."
+    version = "1.0.0"
+    outputFileNamePrefix = 'open-api-3.0.1'
+    format = 'json'
+    outputDirectory = 'build/resources/main/static/docs'
+}
+
+tasks.withType(GenerateSwaggerUI).configureEach {
+    dependsOn 'openapi3'
+
+    delete file('src/main/resources/static/docs/')
+    copy {
+        from "build/resources/main/static/docs"
+        into "src/main/resources/static/docs/"
+    }
+}
+
+tasks.named('asciidoctor') {
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+tasks.named("bootJar") {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
+    dependsOn ':openapi3'
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file(project.layout.buildDirectory.dir("docs/asciidoc").get().asFile.path)
+    into file("src/main/resources/static/docs")
+}
+
+tasks.named("build") {
+    dependsOn copyDocument
 }

--- a/src/main/java/com/rcgc/illdan/global/code/BaseCode.java
+++ b/src/main/java/com/rcgc/illdan/global/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com.rcgc.illdan.global.code;
+
+import com.rcgc.illdan.global.dto.ReasonDto;
+
+public interface BaseCode {
+    ReasonDto getReason();
+    ReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/rcgc/illdan/global/code/BaseErrorCode.java
+++ b/src/main/java/com/rcgc/illdan/global/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.rcgc.illdan.global.code;
+
+import com.rcgc.illdan.global.dto.ErrorReasonDto;
+
+public interface BaseErrorCode {
+    ErrorReasonDto getReason();
+    ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/rcgc/illdan/global/config/SecurityConfig.java
+++ b/src/main/java/com/rcgc/illdan/global/config/SecurityConfig.java
@@ -1,0 +1,88 @@
+package com.rcgc.illdan.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+
+    private static final String[] SWAGGER_URLS = {
+            "/swagger-ui/**", "/v3/api-docs/**"
+    };
+
+    private static final String[] PUBLIC_URLS = {
+            "**"
+    };
+
+    private static final String[] AUTHENTICATED_URLS = {
+    };
+
+    private static final String[] ALLOWED_ORIGINS = {
+            "**"
+    };
+
+    /**
+     * CORS 설정을 구성하는 메서드.
+     *
+     * 허용된 Origin, Method, Header 등을 설정하고, 인증 관련 헤더를 노출합니다.
+     *
+     * @return CORS 설정 객체
+     */
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(Arrays.asList(ALLOWED_ORIGINS));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept", "Set-Cookie"));
+        config.setAllowCredentials(true);
+        config.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    /**
+     * Spring Security의 필터 체인을 구성하는 메서드.
+     *
+     * - HTTP 기본 인증 비활성화
+     * - CSRF 비활성화
+     * - CORS 설정 적용
+     * - 요청 경로별 인증 정책 설정
+     * - JwtFilter를 Security Filter Chain에 추가
+     *
+     * @param httpSecurity HttpSecurity 객체
+     * @return SecurityFilterChain 객체
+     * @throws Exception 필터 체인 구성 실패 시 예외 발생
+     */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .httpBasic(HttpBasicConfigurer::disable)
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(SWAGGER_URLS).permitAll()
+                        .requestMatchers(PUBLIC_URLS).permitAll()
+                        .requestMatchers(AUTHENTICATED_URLS).authenticated()
+                        .anyRequest().authenticated()
+                );
+
+        return httpSecurity.build();
+    }
+}

--- a/src/main/java/com/rcgc/illdan/global/config/SwaggerConfig.java
+++ b/src/main/java/com/rcgc/illdan/global/config/SwaggerConfig.java
@@ -1,0 +1,72 @@
+package com.rcgc.illdan.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rcgc.illdan.global.exception.CustomException;
+import com.rcgc.illdan.global.status.ErrorStatus;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        OpenAPI openAPI = new OpenAPI()
+                .info(new Info()
+                        .title("ILLDAN API Documentation")
+                        .version("v1.0.0")
+                        .description("Spring REST Docs with Swagger UI.")
+                        .contact(new Contact()
+                        .name("Sangho Han")
+                        .url("https://github.com/bbbang105")
+                        .email("hchsa77@gmail.com"))
+                )
+                .servers(List.of(
+                        new Server().url("http://localhost:8085").description("로컬 서버")
+                ));
+
+        // REST Docs에서 생성한 open-api-3.0.1.json 파일 읽어오기
+        try {
+            ClassPathResource resource = new ClassPathResource("static/docs/open-api-3.0.1.json");
+            InputStream inputStream = resource.getInputStream();
+            ObjectMapper mapper = new ObjectMapper();
+
+            // open-api-3.0.1.json 파일을 OpenAPI 객체로 매핑
+            OpenAPI restDocsOpenAPI = mapper.readValue(inputStream, OpenAPI.class);
+
+            // REST Docs에서 생성한 Paths 정보 병합
+            Paths paths = restDocsOpenAPI.getPaths();
+            openAPI.setPaths(paths);
+
+            openAPI.components(restDocsOpenAPI.getComponents());
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorStatus._FAILED_TRANSLATE_SWAGGER);
+        }
+
+        // 액세스 토큰
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
+        openAPI.components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+
+        return openAPI;
+    }
+}

--- a/src/main/java/com/rcgc/illdan/global/dto/ApiResponse.java
+++ b/src/main/java/com/rcgc/illdan/global/dto/ApiResponse.java
@@ -1,0 +1,48 @@
+package com.rcgc.illdan.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.rcgc.illdan.global.code.BaseCode;
+import com.rcgc.illdan.global.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiResponse<T> {
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T result;
+
+    // 성공 응답 - result 포함
+    public static <T> ResponseEntity<ApiResponse<T>> onSuccess(BaseCode code, T result) {
+        ApiResponse<T> response = new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+
+    // 성공 응답 - result 없음
+    public static <T> ResponseEntity<ApiResponse<T>> onSuccess(BaseCode code) {
+        ApiResponse<T> response = new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), null);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+
+    // 실패 응답 - 기본 메시지
+    public static <T> ResponseEntity<ApiResponse<T>> onFailure(BaseErrorCode code) {
+        ApiResponse<T> response = new ApiResponse<>(false, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), null);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+
+    // 실패 응답 - 커스텀 메시지 (result 없음)
+    public static <T> ResponseEntity<ApiResponse<T>> onFailureWithCustomMessage(BaseErrorCode code, String customMessage) {
+        ApiResponse<T> response = new ApiResponse<>(false, code.getReasonHttpStatus().getCode(), customMessage, null);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+
+    // 실패 응답 - Override 메서드용
+    public static <T> ResponseEntity<Object> onFailureForOverrideMethod(BaseErrorCode code, String message) {
+        ApiResponse<T> response = new ApiResponse<>(false, code.getReasonHttpStatus().getCode(), message, null);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/rcgc/illdan/global/dto/ErrorReasonDto.java
+++ b/src/main/java/com/rcgc/illdan/global/dto/ErrorReasonDto.java
@@ -1,0 +1,14 @@
+package com.rcgc.illdan.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDto {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/rcgc/illdan/global/dto/ReasonDto.java
+++ b/src/main/java/com/rcgc/illdan/global/dto/ReasonDto.java
@@ -1,0 +1,14 @@
+package com.rcgc.illdan.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDto {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/rcgc/illdan/global/exception/CustomException.java
+++ b/src/main/java/com/rcgc/illdan/global/exception/CustomException.java
@@ -1,0 +1,25 @@
+package com.rcgc.illdan.global.exception;
+
+import com.rcgc.illdan.global.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final BaseErrorCode errorCode;
+
+    @Override
+    public String getMessage() {
+        return errorCode.getReasonHttpStatus().getMessage();
+    }
+
+    public String getCode() {
+        return errorCode.getReasonHttpStatus().getCode();
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getReasonHttpStatus().getHttpStatus();
+    }
+}

--- a/src/main/java/com/rcgc/illdan/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rcgc/illdan/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,187 @@
+package com.rcgc.illdan.global.exception;
+
+import com.rcgc.illdan.global.dto.ApiResponse;
+import com.rcgc.illdan.global.dto.ErrorReasonDto;
+import com.rcgc.illdan.global.status.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // 커스텀 예외 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleCustomException(CustomException e) {
+        logError(e.getMessage(), e);
+        return ApiResponse.onFailure(e.getErrorCode());
+    }
+
+    // Security 인증 관련 처리
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleSecurityException(SecurityException e) {
+        logError(e.getMessage(), e);
+        return ApiResponse.onFailure(ErrorStatus._UNAUTHORIZED);
+    }
+
+    // IllegalArgumentException 처리 (잘못된 인자가 전달된 경우)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleIllegalArgumentException(IllegalArgumentException e) {
+        String errorMessage = "잘못된 요청입니다: " + e.getMessage();
+        logError("IllegalArgumentException", errorMessage);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // NullPointerException 처리
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleNullPointerException(NullPointerException e) {
+        String errorMessage = "서버에서 예기치 않은 오류가 발생했습니다. 요청을 처리하는 중에 Null 값이 참조되었습니다.";
+        logError("NullPointerException", e);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._INTERNAL_SERVER_ERROR, errorMessage);
+    }
+
+    // NumberFormatException 처리
+    @ExceptionHandler(NumberFormatException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleNumberFormatException(NumberFormatException e) {
+        String errorMessage = "숫자 형식이 잘못되었습니다: " + e.getMessage();
+        logError("NumberFormatException", e);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // IndexOutOfBoundsException 처리
+    @ExceptionHandler(IndexOutOfBoundsException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleIndexOutOfBoundsException(IndexOutOfBoundsException e) {
+        String errorMessage = "인덱스가 범위를 벗어났습니다: " + e.getMessage();
+        logError("IndexOutOfBoundsException", e);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // ConstraintViolationException 처리 (쿼리 파라미터에 올바른 값이 들어오지 않은 경우)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleValidationParameterError(ConstraintViolationException ex) {
+        String errorMessage = ex.getMessage();
+        logError("ConstraintViolationException", errorMessage);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // MissingRequestHeaderException 처리 (필수 헤더가 누락된 경우)
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
+        String errorMessage = "필수 헤더 '" + ex.getHeaderName() + "'가 없습니다.";
+        logError("MissingRequestHeaderException", errorMessage);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // DataIntegrityViolationException 처리 (데이터베이스 제약 조건 위반)
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        String errorMessage = "데이터 무결성 제약 조건을 위반했습니다: " + e.getMessage();
+        logError("DataIntegrityViolationException", e);
+        return ApiResponse.onFailureWithCustomMessage(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // MissingServletRequestParameterException 처리 (필수 쿼리 파라미터가 입력되지 않은 경우)
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
+                                                                          HttpHeaders headers,
+                                                                          HttpStatusCode status,
+                                                                          WebRequest request) {
+        String errorMessage = "필수 파라미터 '" + ex.getParameterName() + "'가 없습니다.";
+        logError("MissingServletRequestParameterException", errorMessage);
+        return ApiResponse.onFailureForOverrideMethod(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // MethodArgumentNotValidException 처리 (RequestBody로 들어온 필드들의 유효성 검증에 실패한 경우)
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatusCode status,
+                                                                  WebRequest request) {
+        String combinedErrors = extractFieldErrors(ex.getBindingResult().getFieldErrors());
+        logError("Validation error", combinedErrors);
+        return ApiResponse.onFailureForOverrideMethod(ErrorStatus._BAD_REQUEST, combinedErrors);
+    }
+
+    // NoHandlerFoundException 처리 (요청 경로에 매핑된 핸들러가 없는 경우)
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex,
+                                                                   HttpHeaders headers,
+                                                                   HttpStatusCode status,
+                                                                   WebRequest request) {
+        String errorMessage = "해당 경로에 대한 핸들러를 찾을 수 없습니다: " + ex.getRequestURL();
+        logError("NoHandlerFoundException", errorMessage);
+        return ApiResponse.onFailureForOverrideMethod(ErrorStatus._NOT_FOUND_HANDLER, errorMessage);
+    }
+
+    // HttpRequestMethodNotSupportedException 처리 (지원하지 않는 HTTP 메소드 요청이 들어온 경우)
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
+                                                                         HttpHeaders headers,
+                                                                         HttpStatusCode status,
+                                                                         WebRequest request) {
+        String errorMessage = "지원하지 않는 HTTP 메소드 요청입니다: " + ex.getMethod();
+        logError("HttpRequestMethodNotSupportedException", errorMessage);
+        return ApiResponse.onFailureForOverrideMethod(ErrorStatus._METHOD_NOT_ALLOWED, errorMessage);
+    }
+
+    // HttpMediaTypeNotSupportedException 처리 (지원하지 않는 미디어 타입 요청이 들어온 경우)
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
+                                                                     HttpHeaders headers,
+                                                                     HttpStatusCode status,
+                                                                     WebRequest request) {
+        String errorMessage = "지원하지 않는 미디어 타입입니다: " + ex.getContentType();
+        logError("HttpMediaTypeNotSupportedException", errorMessage);
+        return ApiResponse.onFailureForOverrideMethod(ErrorStatus._UNSUPPORTED_MEDIA_TYPE, errorMessage);
+    }
+
+    // HttpMessageNotReadableException 처리 (잘못된 JSON 형식)
+    @Override
+    public ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+                                                               HttpHeaders headers,
+                                                               HttpStatusCode status,
+                                                               WebRequest request) {
+        String errorMessage = "요청 본문을 읽을 수 없습니다. 올바른 JSON 형식이어야 합니다.";
+        logError("HttpMessageNotReadableException", ex);
+        return ApiResponse.onFailureForOverrideMethod(ErrorStatus._BAD_REQUEST, errorMessage);
+    }
+
+    // 내부 서버 에러 처리 (500)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ErrorReasonDto>> handleException(Exception e) {
+        logError(e.getMessage(), e);
+        return ApiResponse.onFailure(ErrorStatus._INTERNAL_SERVER_ERROR);
+    }
+
+    // 유효성 검증 오류 메시지 추출 메서드 (FieldErrors)
+    private String extractFieldErrors(List<FieldError> fieldErrors) {
+        return fieldErrors.stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+    }
+
+    // 로그 기록 메서드
+    private void logError(String message, Object errorDetails) {
+        log.error("{}: {}", message, errorDetails);
+    }
+}

--- a/src/main/java/com/rcgc/illdan/global/status/ErrorStatus.java
+++ b/src/main/java/com/rcgc/illdan/global/status/ErrorStatus.java
@@ -1,0 +1,45 @@
+package com.rcgc.illdan.global.status;
+
+import com.rcgc.illdan.global.code.BaseErrorCode;
+import com.rcgc.illdan.global.dto.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // Global Errors
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL-500", "서버 내부 오류가 발생했습니다. 관리자에게 문의하세요."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "GLOBAL-400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "GLOBAL-401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "GLOBAL-403", "접근이 금지된 요청입니다."),
+    _METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL-405", "허용되지 않는 HTTP 메서드입니다."),
+    _UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "GLOBAL-415", "지원되지 않는 미디어 타입입니다."),
+    _NOT_FOUND_HANDLER(HttpStatus.NOT_FOUND, "GLOBAL-404", "요청 경로에 대한 핸들러를 찾을 수 없습니다."),
+    _FAILED_TRANSLATE_SWAGGER(HttpStatus.INTERNAL_SERVER_ERROR, "500", "Rest Docs로 생성된 json파일을 통한 스웨거 변환에 실패하였습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/rcgc/illdan/global/status/SuccessStatus.java
+++ b/src/main/java/com/rcgc/illdan/global/status/SuccessStatus.java
@@ -1,0 +1,39 @@
+package com.rcgc.illdan.global.status;
+
+import com.rcgc.illdan.global.code.BaseCode;
+import com.rcgc.illdan.global.dto.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    // Global
+    _OK(HttpStatus.OK, "GLOBAL-200", "요청 응답에 성공했습니다."),
+    _CREATED(HttpStatus.CREATED, "GLOBAL-201", "요청에 의한 생성에 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/rcgc/illdan/test/presentation/TestController.java
+++ b/src/main/java/com/rcgc/illdan/test/presentation/TestController.java
@@ -1,0 +1,42 @@
+package com.rcgc.illdan.test.presentation;
+
+import com.rcgc.illdan.global.dto.ApiResponse;
+import com.rcgc.illdan.global.exception.CustomException;
+import com.rcgc.illdan.global.status.ErrorStatus;
+import com.rcgc.illdan.global.status.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/test")
+public class TestController {
+
+    /**
+     * 테스트 성공 응답 API
+     *
+     * 이 API는 테스트 목적으로 사용되며, 성공 응답을 반환합니다.
+     * 주어진 요청이 정상적으로 처리될 경우, 200 OK 상태 코드와 함께
+     * 기본 성공 메시지를 포함한 응답을 반환합니다.
+     *
+     * @return 성공 상태 응답 객체
+     */
+    @GetMapping("/response")
+    public ResponseEntity<ApiResponse<SuccessStatus>> getApiResponse() {
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    /**
+     * 테스트 예외 발생 API
+     *
+     * 이 API는 테스트 목적으로 사용되며, 강제로 내부 서버 오류를 발생시킵니다.
+     * 정상적인 요청 흐름에서 예외가 발생했을 때의 처리를 확인하는 용도로 사용됩니다.
+     *
+     * @throws CustomException 내부 서버 오류 예외 발생
+     */
+    @GetMapping("/error")
+    public void getError() {
+        throw new CustomException(ErrorStatus._INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=illdan

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,24 @@
+server:
+  port: 8085
+
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+        show_sql: true
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+  show-actuator: true

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -1,0 +1,16 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "ILLDAN API Documentation",
+    "description" : "Spring REST Docs with Swagger UI.",
+    "version" : "1.0.0"
+  },
+  "servers" : [ {
+    "url" : "http://localhost:8085"
+  } ],
+  "tags" : [ ],
+  "paths" : { },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/src/test/java/com/rcgc/illdan/IlldanApplicationTests.java
+++ b/src/test/java/com/rcgc/illdan/IlldanApplicationTests.java
@@ -3,7 +3,7 @@ package com.rcgc.illdan;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = IlldanApplicationTests.class)
 class IlldanApplicationTests {
 
     @Test


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- API 성공 & 실패 응답 구조를 통일했습니다.
- 전역 에러 처리 기능을 구현하였습니다.
- REST Docs + Swagger 기본 설정을 추가하였습니다. 아직 테스트 코드는 작성하지 않아 설명은 추가 되어 있지 않은 상태입니다.

> Swagger 화면

<img width="1522" alt="image" src="https://github.com/user-attachments/assets/bd071fcc-19cc-4680-b65c-a043b049a784" />

- Spring Security 기본 설정을 추가하였습니다.
- yaml 파일을 추가하고, 환경 변수를 지정하였습니다.

---

## 📝️ 관련 이슈
본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #1 
- Resolves : #2
- Resolves : #3 

---

## 💬 기타 사항 or 추가 코멘트
남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

원래는 각각 PR 올리려 했는데 작업하다 보니..한번에 했네요 😅

- test 도메인은 추후 삭제할 예정입니다! 현재는 api 테스트용으로만 있는 기능이라고 생각해주시면 됩니다.
- Swagger는 애플리케이션 실행 후, http://localhost:8085/swagger-ui/index.html#/ 에서 접근할 수 있습니다. 
- REST Docs는 테스트 코드 작성 후, `./gradle clean build`로 빌드를 진행해주어야 반영이 됩니다. 이 부분은 나중에 다시 설명드리겠습니다!
- 로컬에 있는 MySQL 관련 환경 변수를 인텔리제이에 입력해주셔야 정상적으로 애플리케이션 실행이 됩니다.
```yaml
  datasource:
    url: ${DATABASE_URL}
    username: ${DATABASE_USERNAME}
    password: ${DATABASE_PASSWORD}
```
