### PR TITLE
[fix] : 기한 유효성 검사 시, 당일까지 포함하도록 변경한다

### DIFF
--- a/src/main/java/server/poptato/todo/api/request/DeadlineUpdateRequestDto.java
+++ b/src/main/java/server/poptato/todo/api/request/DeadlineUpdateRequestDto.java
@@ -1,11 +1,11 @@
 package server.poptato.todo.api.request;
 
-import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
 
 import java.time.LocalDate;
 
 public record DeadlineUpdateRequestDto (
-        @Future(message = "마감일은 미래 날짜여야 합니다.")
+        @FutureOrPresent(message = "마감일은 미래 날짜여야 합니다.")
         LocalDate deadline
 ){
 }


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- `🚨 문제 상황` : 마감 기한을 당일로 설정할 수 없었습니다.
- 마감 기한 Request DTO에서는 기한에 대한 `@Future` 유효성 검증을 진행하는데, 이는 `LocalDateTime`을 기준으로 비교합니다.
- 하지만 받는 값은 `2025-02-07`과 같은 `LocalDate` 구조이기에 지난 기한으로 판단되어 유효성 에러가 발생했습니다.
- 때문에 `@FutureOrPresent`로 변경하며 문제를 해결하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #26 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
