### PR TITLE
[feat] : 마감기한 당일이 되면 자동으로 오늘 할 일로 넘어가도록 수정한다

### DIFF
--- a/src/main/java/server/poptato/todo/application/TodoScheduler.java
+++ b/src/main/java/server/poptato/todo/application/TodoScheduler.java
@@ -148,23 +148,20 @@ public class TodoScheduler {
      */
     private void updateDeadlineTodo() {
         List<Long> userIds = userRepository.findAllUserIds();
-        LocalDate today = LocalDate.now();
-
-        updateBacklogTodosToTodayWithBatch(userIds, today);
+        updateBacklogTodosToTodayWithBatch(userIds);
     }
 
     /**
      * 백로그를 오늘 할 일로 옮기는 배치작업을 진행합니다.
      * @param userIds 전체 사용자 ID
-     * @param todayDate 오늘 날짜
      *
      */
     @Transactional
-    private void updateBacklogTodosToTodayWithBatch(List<Long> userIds, LocalDate todayDate) {
+    private void updateBacklogTodosToTodayWithBatch(List<Long> userIds) {
         int batchSize = 50;
         List<List<Long>> userBatches = partitionList(userIds, batchSize);
         for (List<Long> batch : userBatches) {
-            todoRepository.updateBacklogTodosToToday(batch, 0, todayDate);
+            todoRepository.updateBacklogTodosToToday(batch, 0);
             entityManager.flush();
             entityManager.clear();
         }

--- a/src/main/java/server/poptato/todo/application/TodoScheduler.java
+++ b/src/main/java/server/poptato/todo/application/TodoScheduler.java
@@ -159,7 +159,7 @@ public class TodoScheduler {
     @Transactional
     private void updateBacklogTodosToTodayWithBatch(List<Long> userIds) {
         int batchSize = 50;
-        List<List<Long>> userBatches = partitionList(userIds, batchSize);
+        List<List<Long>> userBatches = splitListIntoBatches(userIds, batchSize);
         for (List<Long> batch : userBatches) {
             todoRepository.updateBacklogTodosToToday(batch, 0);
             entityManager.flush();
@@ -172,7 +172,7 @@ public class TodoScheduler {
      * @param userIds 전체 사용자 ID
      * @param batchSize 배치사이즈
      */
-    private List<List<Long>> partitionList(List<Long> userIds, int batchSize) {
+    private List<List<Long>> splitListIntoBatches(List<Long> userIds, int batchSize) {
         List<List<Long>> partitions = new ArrayList<>();
         for (int i = 0; i < userIds.size(); i += batchSize) {
             partitions.add(userIds.subList(i, Math.min(i + batchSize, userIds.size())));

--- a/src/main/java/server/poptato/todo/application/TodoScheduler.java
+++ b/src/main/java/server/poptato/todo/application/TodoScheduler.java
@@ -158,10 +158,11 @@ public class TodoScheduler {
      */
     @Transactional
     private void updateBacklogTodosToTodayWithBatch(List<Long> userIds) {
+        LocalDate today = LocalDate.now();
         int batchSize = 50;
         List<List<Long>> userBatches = splitListIntoBatches(userIds, batchSize);
         for (List<Long> batch : userBatches) {
-            todoRepository.updateBacklogTodosToToday(batch, 0);
+            todoRepository.updateBacklogTodosToToday(today, batch, 0);
             entityManager.flush();
             entityManager.clear();
         }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -63,6 +63,5 @@ public interface TodoRepository {
     List<Todo> findTodosDueToday(@Param("userId") Long userId, LocalDate deadline);
 
     void updateBacklogTodosToToday(@Param("userIds") List<Long> userIds,
-                                   @Param("basicTodayOrder") Integer basicTodayOrder,
-                                   @Param("todayDate") LocalDate todayDate);
+                                   @Param("basicTodayOrder") Integer basicTodayOrder);
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -61,4 +61,8 @@ public interface TodoRepository {
 
     void deleteAllByCategoryId(Long categoryId);
     List<Todo> findTodosDueToday(@Param("userId") Long userId, LocalDate deadline);
+
+    void updateBacklogTodosToToday(@Param("userIds") List<Long> userIds,
+                                   @Param("basicTodayOrder") Integer basicTodayOrder,
+                                   @Param("todayDate") LocalDate todayDate);
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -62,6 +62,7 @@ public interface TodoRepository {
     void deleteAllByCategoryId(Long categoryId);
     List<Todo> findTodosDueToday(@Param("userId") Long userId, LocalDate deadline);
 
-    void updateBacklogTodosToToday(@Param("userIds") List<Long> userIds,
+    void updateBacklogTodosToToday(@Param("today") LocalDate today,
+                                   @Param("userIds") List<Long> userIds,
                                    @Param("basicTodayOrder") Integer basicTodayOrder);
 }

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -85,7 +85,7 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
     @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.deadline = :deadline")
     List<Todo> findTodosDueToday(@Param("userId") Long userId, @Param("deadline") LocalDate deadline);
 
-    @Modifying
+    @Modifying(clearAutomatically=true)
     @Query("""
     UPDATE Todo t
     SET t.type = 'TODAY',

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -91,12 +91,13 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
     SET t.type = 'TODAY',
         t.todayOrder = :basicTodayOrder,
         t.todayStatus = 'INCOMPLETE',
-        t.todayDate = CURRENT_DATE,
+        t.todayDate = :today,
         t.backlogOrder = NULL
     WHERE t.type = 'BACKLOG'
-    AND t.deadline = CURRENT_DATE
+    AND t.deadline = :today
     AND t.userId IN :userIds
 """)
-    void updateBacklogTodosToToday(@Param("userIds") List<Long> userIds,
-                                  @Param("basicTodayOrder") Integer basicTodayOrder);
+    void updateBacklogTodosToToday(@Param("today") LocalDate today,
+                                   @Param("userIds") List<Long> userIds,
+                                   @Param("basicTodayOrder") Integer basicTodayOrder);
 }

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -91,7 +91,7 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
     SET t.type = 'TODAY',
         t.todayOrder = :basicTodayOrder,
         t.todayStatus = 'INCOMPLETE',
-        t.todayDate = :todayDate,
+        t.todayDate = CURRENT_DATE,
         t.backlogOrder = NULL
     WHERE t.type = 'BACKLOG'
     AND t.deadline = CURRENT_DATE

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -3,6 +3,7 @@ package server.poptato.todo.infra.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.poptato.todo.domain.entity.Todo;
@@ -83,4 +84,20 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
 
     @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.deadline = :deadline")
     List<Todo> findTodosDueToday(@Param("userId") Long userId, @Param("deadline") LocalDate deadline);
+
+    @Modifying
+    @Query("""
+    UPDATE Todo t
+    SET t.type = 'TODAY',
+        t.todayOrder = :basicTodayOrder,
+        t.todayStatus = 'INCOMPLETE',
+        t.todayDate = :todayDate,
+        t.backlogOrder = NULL
+    WHERE t.type = 'BACKLOG'
+    AND t.deadline = :todayDate
+    AND t.userId IN :userIds
+""")
+    void updateBacklogTodosToToday(@Param("userIds") List<Long> userIds,
+                                  @Param("basicTodayOrder") Integer basicTodayOrder,
+                                  @Param("todayDate") LocalDate todayDate);
 }

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -94,10 +94,9 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
         t.todayDate = :todayDate,
         t.backlogOrder = NULL
     WHERE t.type = 'BACKLOG'
-    AND t.deadline = :todayDate
+    AND t.deadline = CURRENT_DATE
     AND t.userId IN :userIds
 """)
     void updateBacklogTodosToToday(@Param("userIds") List<Long> userIds,
-                                  @Param("basicTodayOrder") Integer basicTodayOrder,
-                                  @Param("todayDate") LocalDate todayDate);
+                                  @Param("basicTodayOrder") Integer basicTodayOrder);
 }

--- a/src/main/java/server/poptato/user/domain/repository/UserRepository.java
+++ b/src/main/java/server/poptato/user/domain/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository {
     void delete(User user);
     User save(User user);
     List<User> findAll();
+    List<Long> findAllUserIds();
 }

--- a/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
+++ b/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
@@ -6,9 +6,14 @@ import org.springframework.data.jpa.repository.Query;
 import server.poptato.user.domain.entity.User;
 import server.poptato.user.domain.repository.UserRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JpaUserRepository extends UserRepository, JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.socialId = :socialId")
     Optional<User> findBySocialId(@Param("socialId") String socialId);
+
+    @Query("SELECT u.id FROM User u")
+    List<Long> findAllUserIds();
+
 }


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
<img src="https://github.com/user-attachments/assets/4e9ef94c-a6ab-4f76-9eb0-8787381f6b90" width="30%"><img src="https://github.com/user-attachments/assets/4788cd36-6ff9-4964-882e-d5eb910f663d" width="30%">

- 자정이 되면 deadline 당일이 된 할 일을 백로그에서 오늘로 옮긴다.
- 자정이 되면 오늘 할 일이 0개가 돼서 deadline 당일이 된 할 일 전부 today_order = 0박았습니다. 이렇게 되면 먼저 만들어진 것부터 차례대로 아래로 정렬 됩니다.
- 오늘 할 일 순서 변경하는데 문제 없습니다.
- 나중에 대량의 데이터가 생길지도 모르니 기존에 `setter`를 사용한 더티 체킹방식말고  `@Modifying`을 사용해서 50개 id단위로 IN절로 UPDATE처리 해주는데 이렇게 하는게 맞는지 모르겠네요 ........ 상호님 리뷰 부탁드립니다.......

---

## 📝️ 관련 이슈
Resolves : [feat] : 마감기한 당일이 되면 자동으로 오늘 할 일로 넘어가도록 수정한다 #25  

## 💬 기타 사항 or 추가 코멘트

https://hstory0208.tistory.com/entry/JPA-Modifying%EC%9D%B4%EB%9E%80-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EC%A3%BC%EC%9D%98%ED%95%A0%EC%A0%90-%EB%B2%8C%ED%81%AC-%EC%97%B0%EC%82%B0

https://jaehoney.tistory.com/151