### PR TITLE
[feat] : 어제 못 한 일은 백로그 가장 위에 쌓이도록 변경하고, 푸쉬알림의 형태를 수정한다

### DIFF
--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -263,9 +263,9 @@ public class TodoService {
             return;
         }
         if (TodayStatus.COMPLETED.equals(findTodo.getTodayStatus())) {
-            // 미완료로 변경하며, 백로그의 최소 순서를 가져와 반영
-            Integer minBacklogOrder = todoRepository.findMinBacklogOrderByUserIdOrZero(findTodo.getUserId());
-            findTodo.updateYesterdayToInComplete(minBacklogOrder);
+            // 미완료로 변경하며, 백로그의 가장 맨 위에 들어가게 함
+            Integer maxBacklogOrder = todoRepository.findMaxBacklogOrderByUserIdOrZero(findTodo.getUserId() + 1);
+            findTodo.updateYesterdayToInComplete(maxBacklogOrder);
 
             // 기존 완료 기록이 존재하면 삭제, 없으면 예외 발생
             CompletedDateTime completedDateTime = completedDateTimeRepository.findByDateAndTodoId(findTodo.getId(), findTodo.getTodayDate())

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -136,9 +136,9 @@ public class Todo{
         this.backlogOrder = null;
     }
 
-    public void updateYesterdayToInComplete(int minBacklogOrder) {
+    public void updateYesterdayToInComplete(int maxBacklogOrder) {
         this.todayStatus = TodayStatus.COMPLETED;
-        this.backlogOrder = --minBacklogOrder;
+        this.backlogOrder = ++maxBacklogOrder;
     }
 
     public void setType(Type type) {

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -12,10 +12,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TodoRepository {
-    void deleteAllByUserId(Long userId);
 
-    List<Todo> findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(
-            Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus);
+    List<Todo> findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus);
 
     List<Todo> findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(Long userId, LocalDate todayDate);
 
@@ -24,18 +22,18 @@ public interface TodoRepository {
     void delete(Todo todo);
 
     Todo save(Todo todo);
-    Integer findMaxBacklogOrderByUserIdOrZero(Long userId);
+
+    Page<Todo> findByUserIdAndTypeAndTodayStatus(Long userId, Type type, TodayStatus todayStatus, Pageable pageable);
 
     Integer findMaxTodayOrderByUserIdOrZero(Long userId);
 
     Integer findMinTodayOrderByUserIdOrZero(Long userId);
 
-    Page<Todo> findByUserIdAndTypeAndTodayStatus(Long userId, Type type, TodayStatus todayStatus, Pageable pageable);
+    Integer findMaxBacklogOrderByUserIdOrZero(Long userId);
 
-    List<Todo> findByTypeAndTodayStatus(Type today, TodayStatus incomplete);
-
+    /* 25.02.20 : 미사용으로 인한 주석 처리
     Integer findMinBacklogOrderByUserIdOrZero(Long userId);
-
+     */
     default List<Todo> findIncompleteTodays(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus) {
         return findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(
                 userId, type, todayDate, todayStatus);
@@ -50,8 +48,8 @@ public interface TodoRepository {
         return findTodosByUserIdAndCompletedDateTime(userId, localDate, pageable);
     }
     Page<Todo> findTodosByUserIdAndCompletedDateTime(Long userId, LocalDate localDate, Pageable pageable);
+
     List<Todo> findByType(Type type);
-    List<Todo> findByTypeAndUserId(Type type, Long userId);
 
     Page<Todo> findAllBacklogs(Long userId, List<Type> types, TodayStatus status, Pageable pageable);
 
@@ -60,6 +58,7 @@ public interface TodoRepository {
     Page<Todo> findBacklogsByCategoryId(Long userId, Long categoryId, List<Type> types, TodayStatus status, Pageable pageable);
 
     void deleteAllByCategoryId(Long categoryId);
+
     List<Todo> findTodosDueToday(@Param("userId") Long userId, LocalDate deadline);
 
     void updateBacklogTodosToToday(@Param("today") LocalDate today,


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- 사용하지 않는 메서드들을 제거 or 주석 처리 해 두었습니다.

### .filter() 주석 처리
- 자정에 d-day인 할 일들은 잘 들어오지만, 백로그에 쌓인 어제 못 한 일들이 오늘로 들어가지 못 하는 문제가 있었습니다.
- DB를 확인해 보니 타입이 `BACKLOG`가 아닌 `YESTERDAY` 였기에 옮겨지지 않았습니다.
- 이는 스케줄러 동작 시, 오늘 할 일 처리 이후 어제 할 일을 처리하는 과정에서 2번의 수정은 허용하지 않았기 떄문입니다.
- 그렇기에 filter 부분을 제거하고 테스트를 해 보니, 올바르게 들어오는 것을 확인했습니다.
> 🧑🏻‍💻 다만 이 부분은 예전과 동일한 것으로 알고 있는데, 원래도 안 되는 거였는데 인지를 못 했던 것인지 or 리팩토링 과정에서 로직 변경으로 인한 문제인 지는 조금 더 파악해봐야 할 것 같습니다!

### 백로그 가장 위에 쌓이도록 변경
- 어제 못 한 일들이 백로그 가장 아래에 쌓이는 불편함이 있었습니다.
- 때문에 현재 백로그의 `minOrder`이 아닌, `maxOrder`를 가져와 순서를 할당하는 방식으로 수정하였습니다.

### 푸쉬알림 메세지 형태 변경
- 기존에는 `:` 이 포함되어 있었는데, 불필요하다는 의견이 있어 제거하였습니다.

### 트랜잭셔널은 private에서 미작동
```java
@Transactional
private void updateBacklogTodosToTodayWithBatch(List<Long> userIds) {  ... // 기존
protected void updateBacklogTodosToTodayWithBatch(List<Long> userIds) { ... // 변경 후
```
- protected로 변경함으로써 트랜잭셔널이 작동하도록 하였습니다.
> 🧑🏻‍💻 `@Async`랑 `@Transactioanl`을 같은 곳에서 사용하는 것은 지양하는 게 좋다고 합니다! 때문에 추후 스케줄러 부분에서 트랜잭셔널 관련 리팩토링을 해야할 것 같습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #40 
- Resolves : #45 

---

## 💬 기타 사항 or 추가 코멘트
> 🧑🏻‍💻 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
