### PR TITLE
[refactor] : 스케줄러 코드를 리팩토링하고 여러 문제를 해결한다

### DIFF
--- a/src/main/java/server/poptato/auth/status/AuthErrorStatus.java
+++ b/src/main/java/server/poptato/auth/status/AuthErrorStatus.java
@@ -22,6 +22,8 @@ public enum AuthErrorStatus implements BaseErrorCode {
     _HAS_NOT_NEW_APPLE_USER_NAME(HttpStatus.UNAUTHORIZED, "AUTH-011", "[애플] 신규 유저의 name이 존재하지 않습니다."),
     _EXPIRED_APPLE_ID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-012", "[애플] ID 토큰이 만료되었습니다."),
     _INVALID_APPLE_ID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-013", "[애플] ID 토큰이 유효하지 않습니다."),
+    _EXPIRED_OR_NOT_FOUND_REFRESH_TOKEN_IN_REDIS(HttpStatus.UNAUTHORIZED, "AUTH-014", "레디스에 있는 리프레쉬 토큰이 없거나 만료되었습니다."),
+    _REDIS_UNAVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-015", "레디스 서버에 접근할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/server/poptato/external/firebase/service/FcmNotificationScheduler.java
+++ b/src/main/java/server/poptato/external/firebase/service/FcmNotificationScheduler.java
@@ -1,0 +1,29 @@
+package server.poptato.external.firebase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmNotificationScheduler {
+    private final FcmNotificationService fcmNotificationService;
+
+    /**
+     * 비활성 FCM 토큰을 삭제한다.
+     */
+    @Scheduled(cron = "${scheduling.fcmCleanupCron}")
+    public void deleteOldFcmTokens() {
+        fcmNotificationService.deleteOldFcmTokens();
+    }
+
+    /**
+     * 마감일 알림을 전송한다.
+     */
+    @Scheduled(cron = "${scheduling.deadlineNotificationCron}")
+    @Async
+    public void sendDeadlineNotifications() {
+        fcmNotificationService.sendDeadlineNotifications();
+    }
+}

--- a/src/main/java/server/poptato/external/firebase/service/FcmNotificationService.java
+++ b/src/main/java/server/poptato/external/firebase/service/FcmNotificationService.java
@@ -1,0 +1,78 @@
+package server.poptato.external.firebase.service;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.user.domain.entity.Mobile;
+import server.poptato.user.domain.entity.User;
+import server.poptato.user.domain.repository.MobileRepository;
+import server.poptato.user.domain.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FcmNotificationService {
+    private final FCMService fcmService;
+    private final UserRepository userRepository;
+    private final MobileRepository mobileRepository;
+    private final TodoRepository todoRepository;
+
+    /**
+     * 비활성 FCM 토큰을 삭제한다.
+     */
+    public void deleteOldFcmTokens() {
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+        mobileRepository.deleteOldTokens(oneMonthAgo);
+    }
+
+    /**
+     * 마감일 알림을 전송한다.
+     */
+    @Async
+    public void sendDeadlineNotifications() {
+        List<User> users = userRepository.findAll();
+        for (User user : users) {
+            if (Boolean.TRUE.equals(user.getIsPushAlarm())) {
+                sendUserDeadlineNotification(user);
+            }
+        }
+    }
+
+    /**
+     * 특정 유저에게 마감일 알림을 전송한다.
+     */
+    private void sendUserDeadlineNotification(User user) {
+        List<Todo> todosDueToday = todoRepository.findTodosDueToday(user.getId(), LocalDate.now());
+        if (!todosDueToday.isEmpty()) {
+            List<Mobile> mobiles = mobileRepository.findAllByUserId(user.getId());
+            for (Mobile mobile : mobiles) {
+                for (Todo todo : todosDueToday) {
+                    sendPushNotificationOrDeleteFcmToken(mobile.getClientId(), todo.getContent());
+                }
+            }
+        }
+    }
+
+    /**
+     * 푸시 알림을 전송하거나, 유효하지 않은 FCM 토큰을 삭제한다.
+     */
+    private void sendPushNotificationOrDeleteFcmToken(String clientId, String todoContent) {
+        try {
+            fcmService.sendPushNotification(clientId, "오늘 마감 예정인 할 일", todoContent);
+        } catch (FirebaseMessagingException e) {
+            if (e.getMessagingErrorCode().equals(MessagingErrorCode.INVALID_ARGUMENT) ||
+                    e.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
+                mobileRepository.deleteByClientId(clientId);
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/server/poptato/todo/api/TodoController.java
+++ b/src/main/java/server/poptato/todo/api/TodoController.java
@@ -1,23 +1,25 @@
 package server.poptato.todo.api;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import server.poptato.auth.application.service.JwtService;
+import server.poptato.global.response.ApiResponse;
+import server.poptato.global.response.status.SuccessStatus;
 import server.poptato.todo.api.request.*;
 import server.poptato.todo.application.TodoService;
 import server.poptato.todo.application.response.HistoryCalendarListResponseDto;
 import server.poptato.todo.application.response.PaginatedHistoryResponseDto;
 import server.poptato.todo.application.response.TodoDetailResponseDto;
-import server.poptato.global.response.ApiResponse;
-import server.poptato.global.response.status.SuccessStatus;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class TodoController {
 
     private final TodoService todoService;
@@ -53,7 +55,7 @@ public class TodoController {
     @PatchMapping("/swipe")
     public ResponseEntity<ApiResponse<SuccessStatus>> swipe(
             @RequestHeader("Authorization") String authorizationHeader,
-            @Validated @RequestBody SwipeRequestDto swipeRequestDto
+            @Valid @RequestBody SwipeRequestDto swipeRequestDto
     ) {
         todoService.swipe(jwtService.extractUserIdFromToken(authorizationHeader), swipeRequestDto);
         return ApiResponse.onSuccess(SuccessStatus._OK);
@@ -89,7 +91,7 @@ public class TodoController {
     @PatchMapping("/todo/dragAndDrop")
     public ResponseEntity<ApiResponse<SuccessStatus>> dragAndDrop(
             @RequestHeader("Authorization") String authorizationHeader,
-            @Validated @RequestBody TodoDragAndDropRequestDto todoDragAndDropRequestDto
+            @Valid @RequestBody TodoDragAndDropRequestDto todoDragAndDropRequestDto
     ) {
         todoService.dragAndDrop(jwtService.extractUserIdFromToken(authorizationHeader), todoDragAndDropRequestDto);
         return ApiResponse.onSuccess(SuccessStatus._OK);
@@ -127,7 +129,7 @@ public class TodoController {
     public ResponseEntity<ApiResponse<SuccessStatus>> updateDeadline(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long todoId,
-            @Validated @RequestBody DeadlineUpdateRequestDto deadlineUpdateRequestDto
+            @Valid @RequestBody DeadlineUpdateRequestDto deadlineUpdateRequestDto
     ) {
         todoService.updateDeadline(jwtService.extractUserIdFromToken(authorizationHeader), todoId, deadlineUpdateRequestDto);
         return ApiResponse.onSuccess(SuccessStatus._OK);
@@ -147,7 +149,7 @@ public class TodoController {
     public ResponseEntity<ApiResponse<SuccessStatus>> updateContent(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long todoId,
-            @Validated @RequestBody ContentUpdateRequestDto contentUpdateRequestDto
+            @Valid @RequestBody ContentUpdateRequestDto contentUpdateRequestDto
     ) {
         todoService.updateContent(jwtService.extractUserIdFromToken(authorizationHeader), todoId, contentUpdateRequestDto);
         return ApiResponse.onSuccess(SuccessStatus._OK);
@@ -172,6 +174,24 @@ public class TodoController {
     }
 
     /**
+     * 어제 한 일 체크 API.
+     *
+     * 사용자의 어제 한 일 중에서 완료된 항목을 체크하고, 미완료 항목을 백로그로 이동시킵니다.
+     *
+     * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
+     * @param request 미완료 -> 완료로 변경된 todoId 리스트
+     * @return 성공 여부 응답
+     */
+    @PostMapping("/todo/check/yesterdays")
+    public ResponseEntity<ApiResponse<SuccessStatus>> checkYesterdayTodos(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Valid @RequestBody CheckYesterdayTodosRequestDto request
+    ) {
+        todoService.checkYesterdayTodos(jwtService.extractUserIdFromToken(authorizationHeader), request);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    /**
      * 할 일 카테고리 변경 API.
      *
      * 사용자가 특정 할 일의 카테고리를 변경합니다.
@@ -185,7 +205,7 @@ public class TodoController {
     public ResponseEntity<ApiResponse<SuccessStatus>> updateCategory(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long todoId,
-            @RequestBody TodoCategoryUpdateRequestDto todoCategoryUpdateRequestDto
+            @Valid @RequestBody TodoCategoryUpdateRequestDto todoCategoryUpdateRequestDto
     ) {
         todoService.updateCategory(jwtService.extractUserIdFromToken(authorizationHeader), todoId, todoCategoryUpdateRequestDto);
         return ApiResponse.onSuccess(SuccessStatus._OK);

--- a/src/main/java/server/poptato/todo/api/request/CheckYesterdayTodosRequestDto.java
+++ b/src/main/java/server/poptato/todo/api/request/CheckYesterdayTodosRequestDto.java
@@ -1,0 +1,11 @@
+package server.poptato.todo.api.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CheckYesterdayTodosRequestDto(
+        @NotNull(message = "어제 한 일 체크 시, 할 일 리스트는 필수입니다.")
+        List<Long> todoIds
+){
+}

--- a/src/main/java/server/poptato/todo/application/TodoScheduler.java
+++ b/src/main/java/server/poptato/todo/application/TodoScheduler.java
@@ -1,27 +1,21 @@
 package server.poptato.todo.application;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.MessagingErrorCode;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import server.poptato.external.firebase.service.FCMService;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.repository.TodoRepository;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
-import server.poptato.user.domain.entity.Mobile;
-import server.poptato.user.domain.entity.User;
-import server.poptato.user.domain.repository.MobileRepository;
 import server.poptato.user.domain.repository.UserRepository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,234 +23,97 @@ import java.util.stream.Collectors;
 public class TodoScheduler {
     private final TodoRepository todoRepository;
     private final UserRepository userRepository;
-    private final MobileRepository mobileRepository;
-    private final FCMService fcmService;
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final TodoService todoService;
 
     /**
-     * 매일 자정에 할 일의 상태(Type)를 업데이트하고 마감 알림을 전송합니다.
+     * 매일 새벽 특정 시간에 할 일 상태를 업데이트한다.
      */
-    @Scheduled(cron = "0 0 0 * * *")
-    @Transactional
+    @Scheduled(cron = "${scheduling.todoCron}")
     public void updateTodoType() {
-        List<Long> updatedTodoIds = new ArrayList<>();
-        updateTodo(updatedTodoIds);
-        sendDeadlineNotifications();
-        deleteOldFcmTokens();
+        updateTodayTodosAndSave();
+        updateDeadlineTodoAsync();
     }
 
     /**
-     * 할 일의 상태(Type)를 업데이트합니다.
-     *
-     * @param updatedTodoIds 업데이트된 할 일의 ID 목록
+     * 할 일의 상태(Type)를 업데이트하고 저장한다.
      */
-    @Async
-    public void updateTodo(List<Long> updatedTodoIds) {
-        Map<Long, Integer> userIdToStartingOrder = new HashMap<>();
-        Map<Long, List<Todo>> userIdAndTodaysMap = updateTodays(updatedTodoIds, userIdToStartingOrder);
-        List<Todo> yesterdayTodos = updateYesterdays(updatedTodoIds, userIdToStartingOrder);
-        save(userIdAndTodaysMap, yesterdayTodos);
-        updateDeadlineTodo();
+    @Transactional
+    public void updateTodayTodosAndSave() {
+        Map<Long, List<Todo>> userIdAndTodaysMap = updateTodayTodos();
+        saveUpdatedTodos(userIdAndTodaysMap);
     }
 
     /**
-     * 오늘(TODAY) 상태의 할 일을 업데이트합니다.
+     * 오늘(TODAY) 상태의 할 일 중 완료 여부에 따라 상태를 변경한다.
+     * 완료된 반복 할 일은 백로그로 이동하며, 미완료된 할 일은 어제로 변경된다.
      *
-     * @param updatedTodoIds 업데이트된 할 일의 ID 목록
-     * @param userIdToStartingOrder 사용자 ID별 시작 순서 맵
      * @return 사용자 ID별 오늘의 할 일 목록
      */
-    private Map<Long, List<Todo>> updateTodays(List<Long> updatedTodoIds, Map<Long, Integer> userIdToStartingOrder) {
-        Map<Long, List<Todo>> userIdAndTodaysMap = todoRepository.findByType(Type.TODAY)
+    private Map<Long, List<Todo>> updateTodayTodos() {
+        Map<Long, Integer> userIdToStartingOrder = new HashMap<>();
+        Map<Long, List<Todo>> userIdAndTodayTodosMap = todoRepository.findByType(Type.TODAY)
                 .stream()
                 .collect(Collectors.groupingBy(Todo::getUserId));
 
-        userIdAndTodaysMap.forEach((userId, todos) -> {
-            userIdToStartingOrder.putIfAbsent(userId, todoRepository.findMaxBacklogOrderByUserIdOrZero(userId) + 1);
-            int startingOrder = userIdToStartingOrder.get(userId);
+        userIdAndTodayTodosMap.forEach((userId, todos) -> {
+            int startingOrder = userIdToStartingOrder.computeIfAbsent(
+                    userId, id -> todoRepository.findMaxBacklogOrderByUserIdOrZero(id) + 1
+            );
 
             for (Todo todo : todos) {
                 if (todo.getTodayStatus() == TodayStatus.COMPLETED && todo.isRepeat()) {
+                    // 완료한 반복 할 일이라면 백로그로 이동
                     todo.setType(Type.BACKLOG);
                     todo.setTodayStatus(null);
                     todo.setTodayOrder(null);
                     todo.setBacklogOrder(startingOrder++);
-                    updatedTodoIds.add(todo.getId());
-                    continue;
-                }
-
-                if (todo.getTodayStatus() == TodayStatus.INCOMPLETE) {
+                } else if (todo.getTodayStatus() == TodayStatus.INCOMPLETE) {
+                    // 미완료라면 모두 '어제'로 이동
                     todo.setType(Type.YESTERDAY);
                     todo.setTodayOrder(null);
                     todo.setBacklogOrder(startingOrder++);
-                    updatedTodoIds.add(todo.getId());
                 }
             }
-
-            userIdToStartingOrder.put(userId, startingOrder);
         });
-        return userIdAndTodaysMap;
+
+        return userIdAndTodayTodosMap;
     }
 
     /**
-     * 어제(YESTERDAY) 상태의 할 일을 업데이트합니다.
-     *
-     * @param updatedTodoIds 업데이트된 할 일의 ID 목록
-     * @param userIdToStartingOrder 사용자 ID별 시작 순서 맵
-     * @return 업데이트된 어제의 할 일 목록
-     */
-    private List<Todo> updateYesterdays(List<Long> updatedTodoIds, Map<Long, Integer> userIdToStartingOrder) {
-        return todoRepository.findByType(Type.YESTERDAY)
-                .stream()
-                /* 25.02.20 : 미사용으로 인한 주석 처리
-                .filter(todo -> !updatedTodoIds.contains(todo.getId()))
-                */
-                .peek(todo -> {
-                    Long userId = todo.getUserId();
-
-                    userIdToStartingOrder.putIfAbsent(userId, todoRepository.findMaxBacklogOrderByUserIdOrZero(userId) + 1);
-                    int startingOrder = userIdToStartingOrder.get(userId);
-
-                    if (todo.getTodayStatus() == TodayStatus.INCOMPLETE) {
-                        todo.setType(Type.BACKLOG);
-                        todo.setTodayStatus(null);
-                        todo.setBacklogOrder(startingOrder++);
-                    } else if (todo.getTodayStatus() == TodayStatus.COMPLETED && todo.isRepeat()) {
-                        todo.setType(Type.BACKLOG);
-                        todo.setTodayStatus(null);
-                        todo.setBacklogOrder(startingOrder++);
-                    }
-
-                    userIdToStartingOrder.put(userId, startingOrder);
-                })
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * 업데이트된 할 일을 저장합니다.
+     * 업데이트된 할 일을 한 번에 저장한다.
      *
      * @param userIdAndTodaysMap 사용자 ID별 오늘의 할 일 목록
-     * @param yesterdayTodos 업데이트된 어제의 할 일 목록
      */
-    private void save(Map<Long, List<Todo>> userIdAndTodaysMap, List<Todo> yesterdayTodos) {
-        for (Todo todo : userIdAndTodaysMap.values().stream().flatMap(List::stream).toList()) {
-            todoRepository.save(todo);
-        }
-        for (Todo todo : yesterdayTodos) {
-            todoRepository.save(todo);
-        }
+    private void saveUpdatedTodos(Map<Long, List<Todo>> userIdAndTodaysMap) {
+        userIdAndTodaysMap.values().stream()
+                .flatMap(List::stream)
+                .forEach(todoRepository::save);
     }
 
     /**
-     * 마감기한 날짜가 된 할 일을 오늘 할 일로 옮깁니다.
-     *
-     */
-    private void updateDeadlineTodo() {
-        List<Long> userIds = userRepository.findAllUserIds();
-        updateBacklogTodosToTodayWithBatch(userIds);
-    }
-
-    /**
-     * 백로그를 오늘 할 일로 옮기는 배치작업을 진행합니다.
-     * @param userIds 전체 사용자 ID
-     *
-     */
-    @Transactional
-    protected void updateBacklogTodosToTodayWithBatch(List<Long> userIds) {
-        LocalDate today = LocalDate.now();
-        int batchSize = 50;
-        List<List<Long>> userBatches = splitListIntoBatches(userIds, batchSize);
-        for (List<Long> batch : userBatches) {
-            todoRepository.updateBacklogTodosToToday(today, batch, 0);
-            entityManager.flush();
-            entityManager.clear();
-        }
-    }
-
-    /**
-     * 유저 아이디 리스트를 배치 사이즈로 나누는 작업을 합니다.
-     * @param userIds 전체 사용자 ID
-     * @param batchSize 배치사이즈
-     */
-    private List<List<Long>> splitListIntoBatches(List<Long> userIds, int batchSize) {
-        List<List<Long>> partitions = new ArrayList<>();
-        for (int i = 0; i < userIds.size(); i += batchSize) {
-            partitions.add(userIds.subList(i, Math.min(i + batchSize, userIds.size())));
-        }
-        return partitions;
-    }
-
-    /**
-     * 마감 알림을 전송합니다.
+     * 마감기한이 된 할 일을 오늘 할 일(TODAY)로 변경한다.
      */
     @Async
-    public void sendDeadlineNotifications() {
-        List<User> users = userRepository.findAll();
+    public void updateDeadlineTodoAsync() {
+        LocalDate today = LocalDate.now();
+        int batchSize = 50;
 
-        for (User user : users) {
-            if (Boolean.TRUE.equals(user.getIsPushAlarm())) {
-                List<Todo> todosDueToday = todoRepository.findTodosDueToday(user.getId(), LocalDate.now());
-                sendFcmMessage(user, todosDueToday);
-            }
-        }
+        List<Long> userIds = userRepository.findAllUserIds();
+        splitListIntoBatches(userIds, batchSize).forEach(batch -> {
+            todoService.processUpdateDeadlineTodos(today, batch);
+        });
     }
 
     /**
-     * FCM 메시지를 전송합니다.
+     * 유저 ID 리스트를 배치 크기 단위로 나눈다.
      *
-     * @param user 알림을 받을 사용자
-     * @param todosDueToday 오늘 마감 예정인 할 일 목록
+     * @param userIds   전체 사용자 ID 목록
+     * @param batchSize 배치 크기
+     * @return 배치된 유저 ID 목록
      */
-    private void sendFcmMessage(User user, List<Todo> todosDueToday) {
-        if (!todosDueToday.isEmpty()) {
-            List<Mobile> mobiles = mobileRepository.findAllByUserId(user.getId());
-            for (Mobile mobile : mobiles) {
-                for (Todo todo : todosDueToday) {
-                    String todoContent = formatTodoContent(todo);
-                    sendPushNotificationOrDeleteFcmToken(mobile.getClientId(), todoContent);
-                }
-            }
-        }
-    }
-
-    private void sendPushNotificationOrDeleteFcmToken(String clientId, String todoContent) {
-        try {
-            fcmService.sendPushNotification(
-                    clientId,
-                    "오늘 마감 예정인 할 일",
-                    todoContent
-            );
-        } catch (FirebaseMessagingException e) {
-            if (e.getMessagingErrorCode().equals(MessagingErrorCode.INVALID_ARGUMENT)) {
-                // 토큰이 유효하지 않은 경우
-                mobileRepository.deleteByClientId(clientId);
-            } else if (e.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
-                // 재발급된 이전 토큰인 경우
-                mobileRepository.deleteByClientId(clientId);
-            }
-            else {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    /**
-     * 비활성 fcm토큰을 삭제하는 메서드.
-     * timestamp를 갱신한지 한달이 지난 fmc토큰을 삭제한다.
-     */
-    private void deleteOldFcmTokens() {
-        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
-        mobileRepository.deleteOldTokens(oneMonthAgo);
-    }
-
-    /**
-     * 할 일 내용을 포맷합니다.
-     *
-     * @param todo 할 일 객체
-     * @return 포맷된 할 일 내용
-     */
-    private String formatTodoContent(Todo todo) {
-        return todo.getContent();
+    private List<List<Long>> splitListIntoBatches(List<Long> userIds, int batchSize) {
+        return new ArrayList<>(userIds.stream()
+                .collect(Collectors.groupingBy(i -> i / batchSize))
+                .values());
     }
 }

--- a/src/main/java/server/poptato/todo/application/TodoScheduler.java
+++ b/src/main/java/server/poptato/todo/application/TodoScheduler.java
@@ -13,7 +13,6 @@ import server.poptato.user.domain.repository.UserRepository;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -50,15 +49,12 @@ public class TodoScheduler {
      * @return 사용자 ID별 오늘의 할 일 목록
      */
     private Map<Long, List<Todo>> updateTodayTodos() {
-        Map<Long, Integer> userIdToStartingOrder = new HashMap<>();
         Map<Long, List<Todo>> userIdAndTodayTodosMap = todoRepository.findByType(Type.TODAY)
                 .stream()
                 .collect(Collectors.groupingBy(Todo::getUserId));
 
         userIdAndTodayTodosMap.forEach((userId, todos) -> {
-            int startingOrder = userIdToStartingOrder.computeIfAbsent(
-                    userId, id -> todoRepository.findMaxBacklogOrderByUserIdOrZero(id) + 1
-            );
+            int startingOrder = todoRepository.findMaxBacklogOrderByUserIdOrZero(userId) + 1;
 
             for (Todo todo : todos) {
                 if (todo.getTodayStatus() == TodayStatus.COMPLETED && todo.isRepeat()) {

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Todo{
+public class Todo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -31,9 +31,6 @@ public interface TodoRepository {
 
     Integer findMaxBacklogOrderByUserIdOrZero(Long userId);
 
-    /* 25.02.20 : 미사용으로 인한 주석 처리
-    Integer findMinBacklogOrderByUserIdOrZero(Long userId);
-     */
     default List<Todo> findIncompleteTodays(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus) {
         return findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(
                 userId, type, todayDate, todayStatus);
@@ -47,6 +44,7 @@ public interface TodoRepository {
     default Page<Todo> findHistories(Long userId,LocalDate localDate, Pageable pageable) {
         return findTodosByUserIdAndCompletedDateTime(userId, localDate, pageable);
     }
+
     Page<Todo> findTodosByUserIdAndCompletedDateTime(Long userId, LocalDate localDate, Pageable pageable);
 
     List<Todo> findByType(Type type);
@@ -64,4 +62,12 @@ public interface TodoRepository {
     void updateBacklogTodosToToday(@Param("today") LocalDate today,
                                    @Param("userIds") List<Long> userIds,
                                    @Param("basicTodayOrder") Integer basicTodayOrder);
+
+    /**
+     * 어제 한 일 중 미완료된 할 일 목록 조회.
+     *
+     * @param userId 사용자 ID
+     * @return 미완료된 어제의 할 일 목록
+     */
+    List<Todo> findIncompleteYesterdays(Long userId);
 }

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -100,4 +100,15 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
     void updateBacklogTodosToToday(@Param("today") LocalDate today,
                                    @Param("userIds") List<Long> userIds,
                                    @Param("basicTodayOrder") Integer basicTodayOrder);
+
+    @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.type = :type " +
+            "AND t.todayStatus = :status ORDER BY t.todayOrder DESC")
+    List<Todo> findIncompleteYesterdays(
+            @Param("userId") Long userId,
+            @Param("type") Type type,
+            @Param("status") TodayStatus status);
+
+    @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.type = 'YESTERDAY' " +
+            "AND t.todayStatus = 'INCOMPLETE' ORDER BY t.todayOrder DESC")
+    List<Todo> findIncompleteYesterdays(@Param("userId") Long userId);
 }

--- a/src/main/java/server/poptato/user/domain/repository/MobileRepository.java
+++ b/src/main/java/server/poptato/user/domain/repository/MobileRepository.java
@@ -12,5 +12,5 @@ public interface MobileRepository {
     void deleteByClientId(String clientId);
     List<Mobile> findAllByUserId(Long userId);
     Optional<Mobile> findByClientId(String clientId);
-    int deleteOldTokens(LocalDateTime localDateTime);
+    void deleteOldTokens(LocalDateTime localDateTime);
 }

--- a/src/main/java/server/poptato/user/infra/repository/JpaMobileRepository.java
+++ b/src/main/java/server/poptato/user/infra/repository/JpaMobileRepository.java
@@ -14,6 +14,6 @@ public interface JpaMobileRepository extends MobileRepository, JpaRepository<Mob
 
     @Modifying
     @Transactional
-    @Query("DELETE FROM Mobile m WHERE m.modify_date < :localDateTime")
-    int deleteOldTokens(@Param("localDateTime") LocalDateTime localDateTime);
+    @Query("DELETE FROM Mobile m WHERE m.modifyDate < :localDateTime")
+    void deleteOldTokens(@Param("localDateTime") LocalDateTime localDateTime);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,3 +69,8 @@ springdoc:
   api-docs:
     path: /v3/api-docs
   show-actuator: false
+
+scheduling:
+  todoCron: ${TODO_CRON}  # 할 일 상태 업데이트 스케줄
+  deadlineNotificationCron: ${DEADLINE_NOTIFICATION_CRON}  # 마감일 알림 스케줄
+  fcmCleanupCron: ${FCM_CLEANUP_CRON}  # 비활성 FCM 토큰 삭제 스케줄

--- a/src/test/java/server/poptato/todo/api/TodoBacklogControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoBacklogControllerTest.java
@@ -152,7 +152,7 @@ public class TodoBacklogControllerTest extends ControllerTestConfig {
     }
 
     @Test
-    @DisplayName("어제의 백로그를 조회한다.")
+    @DisplayName("어제의 미완료 할 일들을 조회한다.")
     public void getYesterdays() throws Exception {
         // given
         PaginatedYesterdayResponseDto response = new PaginatedYesterdayResponseDto(List.of(), 1);
@@ -182,8 +182,8 @@ public class TodoBacklogControllerTest extends ControllerTestConfig {
                         preprocessResponse(prettyPrint()),
                         resource(
                                 ResourceSnippetParameters.builder()
-                                        .tag("Todo-Backlog API")
-                                        .description("어제의 백로그를 조회한다.")
+                                        .tag("Todo-Yesterday API")
+                                        .description("어제의 미완료 할 일들을 조회한다.")
                                         .queryParameters(
                                                 parameterWithName("page").description("요청 페이지 번호"),
                                                 parameterWithName("size").description("페이지 크기")

--- a/src/test/java/server/poptato/todo/api/TodoControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoControllerTest.java
@@ -633,4 +633,52 @@ public class TodoControllerTest extends ControllerTestConfig {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("어제 한 일을 체크한다.")
+    public void checkYesterdayTodos() throws Exception {
+        // given
+        CheckYesterdayTodosRequestDto request = new CheckYesterdayTodosRequestDto(List.of(1L, 2L, 3L));
+        Mockito.doNothing().when(todoService).checkYesterdayTodos(anyLong(), any(CheckYesterdayTodosRequestDto.class));
+        Mockito.when(jwtService.extractUserIdFromToken(token)).thenReturn(1L);
+
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/todo/check/yesterdays")
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .content(requestContent)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("GLOBAL-200"))
+                .andExpect(jsonPath("$.message").value("요청 응답에 성공했습니다."))
+
+                // docs
+                .andDo(MockMvcRestDocumentationWrapper.document("todo/check-yesterdays",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Todo-Yesterday API")
+                                        .description("어제 한 일을 체크한다.")
+                                        .requestFields(
+                                                fieldWithPath("todoIds").type(JsonFieldType.ARRAY).description("어제 한 일 중 체크된 할 일 ID 목록")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                                        )
+                                        .responseSchema(Schema.schema("BaseResponse"))
+                                        .build()
+                        )
+                ));
+    }
 }


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 0. 할 일 스케줄러 로직 수정

- 기존 스케줄러 로직에는 불필요한 부분이 많고, 반복 할 일과 관련해서 문제가 발생할 여지가 있었기에 아래와 같이 로직을 수정하였습니다.

1. 자정이 되면 기존 `오늘`에 있던 할 일들 중 `미완료` 상태인 일들만 `YESTERDAY` 타입으로 변경한다.
    - `반복 할 일`도 동일하게 적용된다.
2. 프론트에서 `어제` 를 조회한 후, 유저의 `미완료` 할 일 들이 있다면 체크하는 화면을 띄운다.
    - 기존 `어제` 조회 API를 사용한다.
3. `어제` 일 중에서 체크하여 `미완료 -> 완료`가 된 **todoId 리스트를 DTO로 API 요청**한다.
    - 기존에 없는 로직이기에, **새로운 API 생성**이 필요하다.
4. 체크된 할 일들은 `COMPLETED`로 변경되고, 체크되지 않은 할 일들은 `BACKLOG` 타입으로 변경되어 `할 일` 페이지에 들어간다.
5. 만약 여기서 `반복 할 일`을 체크하여 `미완료 -> 완료` 가 되었다면, **완료 기록을 저장**하고 **새로운 반복 할 일 객체를 만들어 백로그에 저장**한다.
    - 이를 통해 `반복 할 일`을 체크했다고 `백로그`에서 사라지는 경우를 방지할 수 있다.

수정된 로직에 따라 아래 기능들을 구현하였습니다.

<br>

### 1. 어제 한 일 체크 API 구현

- 스케줄러 기능 하나만으로는 어제의 반복 할 일을 체크했을 때 사라져버리는 문제를 해결할 수 없었습니다.
- 때문에 `어제 할 일 체크` 라는 새로운 API를 구현하였습니다.
- 이는 자정이 지난 후 유저가 처음 접속하면 체크하게 되는 구조입니다. (어제 미완료 할 일이 존재한다면)

<img width="502" alt="image" src="https://github.com/user-attachments/assets/dad152ff-9d0d-4060-9ad9-1857d84a833c" />

- 두 번째 API는 기존에 있던 것이고, 첫 번째 API를 추가하였습니다.

<br>

### 2. 스케줄러에서 불필요한 로직 제거

- 기존에는 `YESTERDAY` 타입의 할 일들까지 처리하는 로직이 있었습니다.
- 허나, `YESTERDAY` 는 스케줄러가 돌아간 후 유저가 첫 접속하기까지만 의미가 있는 것이고 그 이후에는 접근하는 것이 불필요하다고 판단했습니다.
- 때문에 기존에 있던 아래 로직을 제거했습니다.

```java
    /**
     * 어제(YESTERDAY) 상태의 할 일을 업데이트합니다.
     *
     * @param updatedTodoIds 업데이트된 할 일의 ID 목록
     * @param userIdToStartingOrder 사용자 ID별 시작 순서 맵
     * @return 업데이트된 어제의 할 일 목록
     */
    private List<Todo> updateYesterdays(List<Long> updatedTodoIds, Map<Long, Integer> userIdToStartingOrder) {
        return todoRepository.findByType(Type.YESTERDAY)
                .stream()
                /* 25.02.20 : 미사용으로 인한 주석 처리
                .filter(todo -> !updatedTodoIds.contains(todo.getId()))
                */
                .peek(todo -> {
                    Long userId = todo.getUserId();

                    userIdToStartingOrder.putIfAbsent(userId, todoRepository.findMaxBacklogOrderByUserIdOrZero(userId) + 1);
                    int startingOrder = userIdToStartingOrder.get(userId);

                    if (todo.getTodayStatus() == TodayStatus.INCOMPLETE) {
                        todo.setType(Type.BACKLOG);
                        todo.setTodayStatus(null);
                        todo.setBacklogOrder(startingOrder++);
                    } else if (todo.getTodayStatus() == TodayStatus.COMPLETED && todo.isRepeat()) {
                        todo.setType(Type.BACKLOG);
                        todo.setTodayStatus(null);
                        todo.setBacklogOrder(startingOrder++);
                    }

                    userIdToStartingOrder.put(userId, startingOrder);
                })
                .collect(Collectors.toList());
    }
```

<br>

### 3. 할 일 스케줄러와 FCM 토큰 스케줄러의 분리

- `TodoScheduler` 에서 할 일 상태 변경, 마감일 할 일 추가, FCM 토큰 관리 등 너무 많은 일들을 진행하고 있었기에, 분리의 필요성을 느꼈습니다.
- 때문에 FCM 토큰과 관련한 스케줄러 기능들은 따로 분리하였습니다.

```java
package server.poptato.external.firebase.service;

import lombok.RequiredArgsConstructor;
import org.springframework.scheduling.annotation.Async;
import org.springframework.scheduling.annotation.Scheduled;
import org.springframework.stereotype.Service;

@Service
@RequiredArgsConstructor
public class FcmNotificationScheduler {
    private final FcmNotificationService fcmNotificationService;

    /**
     * 비활성 FCM 토큰을 삭제한다.
     */
    @Scheduled(cron = "${scheduling.fcmCleanupCron}")
    public void deleteOldFcmTokens() {
        fcmNotificationService.deleteOldFcmTokens();
    }

    /**
     * 마감일 알림을 전송한다.
     */
    @Scheduled(cron = "${scheduling.deadlineNotificationCron}")
    @Async
    public void sendDeadlineNotifications() {
        fcmNotificationService.sendDeadlineNotifications();
    }
}
```
<br>

### 4. 스케줄러 실행시간 환경변수로 분리

- 기존에 하드코딩 되어 있던 스케줄러 실행시간을, 환경변수로 분리하여 변경을 용이하게 하였습니다.
- 또한 푸쉬알림이 2번씩 가는 문제를 해결하기 위해서 IOS 출시 이후 테스트 서버의 스케줄러 기능을 막아야하는데, 불필요하게 코드를 변경하지 않고 막기 위해서 더욱 필요하다고 판단했습니다.

```
# 스케줄러 설정
TODO_CRON=0 0 0 * * *
DEADLINE_NOTIFICATION_CRON=1 0 0 * * *
FCM_CLEANUP_CRON=2 0 0 * * *
```

- 할 일 스케줄러는 `00:00`에 작동합니다.
- 마감일 할 일 넣는 스케줄러는 `00:01`에 작동합니다.
- FCM 토큰 관련 스케줄러는 `00:02`에 작동합니다.

> 로컬에서 위 부분 넣어주셔야 합니다!!

<br>

### 5. 레디스 접속 불가 에러처리 추가

- 아직 해결하지는 못 한 문제이지만, 레디스와 접속이 되지 않는 (timeout) 에러에 대해서는 처리가 되어있지 않았습니다.
- 때문에 이를 처리하는 부분을 추가하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #35 
- Resolves : #50

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

- [관련 내용 정리 노션](https://www.notion.so/19dd60b563cc8055b8daf56fbef22a76?pvs=4)
