### PR TITLE
[feat] : 카테고리 예외 처리 문제를 해결한다

### DIFF
--- a/src/main/java/server/poptato/category/validator/CategoryValidator.java
+++ b/src/main/java/server/poptato/category/validator/CategoryValidator.java
@@ -8,6 +8,8 @@ import server.poptato.category.domain.repository.CategoryRepository;
 import server.poptato.category.status.CategoryErrorStatus;
 import server.poptato.global.exception.CustomException;
 
+import java.util.Objects;
+
 /**
  * 카테고리 관련 유효성 검증을 처리하는 클래스입니다.
  */
@@ -32,7 +34,7 @@ public class CategoryValidator {
         Category findCategory = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST));
 
-        if (findCategory.getUserId() != userId && findCategory.getUserId() != -1L) {
+        if (!Objects.equals(findCategory.getUserId(), userId) && !Objects.equals(findCategory.getUserId(), -1L)) {
             log.warn("🚨 Category ownership mismatch! categoryId={}, requested by userId={}, but belongs to userId={}",
                     categoryId, userId, findCategory.getUserId());
             throw new CustomException(CategoryErrorStatus._CATEGORY_USER_NOT_MATCH);
@@ -53,7 +55,7 @@ public class CategoryValidator {
         Category findCategory = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST));
 
-        if (findCategory.getUserId() != userId && findCategory.getUserId() != -1L) {
+        if (!Objects.equals(findCategory.getUserId(), userId) && !Objects.equals(findCategory.getUserId(), -1L)) {
             log.warn("🚨 Validation failed! userId={} tried to access categoryId={} owned by userId={}",
                     userId, categoryId, findCategory.getUserId());
             throw new CustomException(CategoryErrorStatus._CATEGORY_USER_NOT_MATCH);

--- a/src/main/java/server/poptato/category/validator/CategoryValidator.java
+++ b/src/main/java/server/poptato/category/validator/CategoryValidator.java
@@ -1,6 +1,7 @@
 package server.poptato.category.validator;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import server.poptato.category.domain.entity.Category;
 import server.poptato.category.domain.repository.CategoryRepository;
@@ -10,6 +11,7 @@ import server.poptato.global.exception.CustomException;
 /**
  * 카테고리 관련 유효성 검증을 처리하는 클래스입니다.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CategoryValidator {
@@ -29,7 +31,10 @@ public class CategoryValidator {
     public Category validateAndReturnCategory(Long userId, Long categoryId) {
         Category findCategory = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST));
+
         if (findCategory.getUserId() != userId && findCategory.getUserId() != -1L) {
+            log.warn("🚨 Category ownership mismatch! categoryId={}, requested by userId={}, but belongs to userId={}",
+                    categoryId, userId, findCategory.getUserId());
             throw new CustomException(CategoryErrorStatus._CATEGORY_USER_NOT_MATCH);
         }
         return findCategory;
@@ -47,7 +52,10 @@ public class CategoryValidator {
     public void validateCategory(Long userId, Long categoryId) {
         Category findCategory = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST));
+
         if (findCategory.getUserId() != userId && findCategory.getUserId() != -1L) {
+            log.warn("🚨 Validation failed! userId={} tried to access categoryId={} owned by userId={}",
+                    userId, categoryId, findCategory.getUserId());
             throw new CustomException(CategoryErrorStatus._CATEGORY_USER_NOT_MATCH);
         }
     }


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제 
- 유저 id와 카테고리 id가 동일함에도 둘이 다르게 되어 카테고리 예외 처리가 되었습니다. 해당 처리 때문에 새로운 카테고리를 만들고 새로운 투두를 만들 수 없었습니다.

### ✅ 해결
- 기존에는 두 Long 타입을 `!=`로 비교하였습니다. Java는 내부적으로 `-128 ~ 127` 범위의 값은 캐싱하여 동일한 취급을 하기에 유저 id가 127인 유저까지는 문제가 없었습니다. 하지만 그 이후(128)부터는 비교가 제대로 되지 않았기에, 비교 방식을 아래와 같이 변경하였습니다.

> 기존
```java
    public Category validateAndReturnCategory(Long userId, Long categoryId) {
        Category findCategory = categoryRepository.findById(categoryId)
                .orElseThrow(() -> new CategoryException(CATEGORY_NOT_EXIST));
        if (findCategory.getUserId() != userId && findCategory.getUserId() != -1L) throw new CategoryException(CATEGORY_USER_NOT_MATCH);
        return findCategory;
    }

    public void validateCategory(Long userId, Long categoryId) {
        Category findCategory = categoryRepository.findById(categoryId)
                .orElseThrow(() -> new CategoryException(CATEGORY_NOT_EXIST));
        if (findCategory.getUserId() != userId && findCategory.getUserId() != -1L) throw new CategoryException(CATEGORY_USER_NOT_MATCH);
    }
```

> 변경 

```java
    public Category validateAndReturnCategory(Long userId, Long categoryId) {
        Category findCategory = categoryRepository.findById(categoryId)
                .orElseThrow(() -> new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST));

        if (!Objects.equals(findCategory.getUserId(), userId) && !Objects.equals(findCategory.getUserId(), -1L)) {
            log.warn("🚨 Category ownership mismatch! categoryId={}, requested by userId={}, but belongs to userId={}",
                    categoryId, userId, findCategory.getUserId());
            throw new CustomException(CategoryErrorStatus._CATEGORY_USER_NOT_MATCH);
        }
        return findCategory;
    }

    public void validateCategory(Long userId, Long categoryId) {
        Category findCategory = categoryRepository.findById(categoryId)
                .orElseThrow(() -> new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST));

        if (!Objects.equals(findCategory.getUserId(), userId) && !Objects.equals(findCategory.getUserId(), -1L)) {
            log.warn("🚨 Validation failed! userId={} tried to access categoryId={} owned by userId={}",
                    userId, categoryId, findCategory.getUserId());
            throw new CustomException(CategoryErrorStatus._CATEGORY_USER_NOT_MATCH);
        }
    }
```

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #66 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

- [참고 블로그1](https://dami97.tistory.com/24)
