### PR TITLE
[fix] : 어제 한 일 체크 이후 반복 할 일 새 객체를 만드는 과정에서 누락된 중요 표시와 백로그 순서를 추가한다

### DIFF
--- a/src/main/java/server/poptato/category/application/CategoryService.java
+++ b/src/main/java/server/poptato/category/application/CategoryService.java
@@ -20,7 +20,6 @@ import server.poptato.global.exception.CustomException;
 import server.poptato.global.util.FileUtil;
 import server.poptato.todo.domain.repository.TodoRepository;
 import server.poptato.user.domain.value.MobileType;
-import server.poptato.user.domain.value.SocialType;
 import server.poptato.user.validator.UserValidator;
 
 import java.util.ArrayList;

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -267,6 +267,7 @@ public class TodoService {
     private void updateYesterdayIsCompleted(Todo findTodo) {
         // 완료 처리
         LocalDateTime yesterday = LocalDateTime.of(findTodo.getTodayDate(), LocalTime.of(23, 59));
+        int existBacklogOrder = findTodo.getBacklogOrder();
         findTodo.updateYesterdayToCompleted();
         completedDateTimeRepository.save(
                 CompletedDateTime.builder()
@@ -282,8 +283,9 @@ public class TodoService {
                     .categoryId(findTodo.getCategoryId())
                     .content(findTodo.getContent())
                     .type(Type.BACKLOG)
-                    .todayStatus(TodayStatus.INCOMPLETE)
+                    .backlogOrder(existBacklogOrder)
                     .todayDate(LocalDate.now())
+                    .isBookmark(findTodo.isBookmark())
                     .isRepeat(true)
                     .deadline(findTodo.getDeadline())
                     .build();


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제
1. 어제 한 일 체크에서 반복 할 일을 체크하는 경우 -> 새 객체를 생성해 다시 백로그로 들어갑니다.
2. 해당 과정에서 기존 객체를 완료 처리 한 후 정보를 옮겼으므로, 백로그 순서가 null로 들어갔습니다.
3. 또한 중요 표시 부분이 누락되어있었습니다.

### ✅ 해결
1. 누락된 부분들을 추가하였고, 완료 처리를 하기 전 백로그 순서를 변수에 할당해둠으로써 해결하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #69 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
