### PR TITLE
[feat] : 기록 페이지에 마감기한이 정해진 할일이 보이도록 구현한다

### DIFF
--- a/src/main/java/server/poptato/todo/api/TodoController.java
+++ b/src/main/java/server/poptato/todo/api/TodoController.java
@@ -262,7 +262,7 @@ public class TodoController {
      * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
      * @param year 조회할 연도
      * @param month 조회할 월
-     * @return 해당 연도와 월의 할 일 히스토리 날짜 목록
+     * @return 해당 연도와 월의 할 일 히스토리 날짜 목록, 미래 날짜의 경우 날짜와 마감날짜가 설정된 백로그 개수
      */
     @GetMapping("/calendar")
     public ResponseEntity<ApiResponse<HistoryCalendarListResponseDto>> getHistoryCalendarDateList(

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -29,6 +29,7 @@ import server.poptato.todo.status.TodoErrorStatus;
 import server.poptato.user.domain.value.MobileType;
 import server.poptato.user.validator.UserValidator;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -391,7 +392,7 @@ public class TodoService {
 
         Map<LocalDate, Integer> backlogCountByDate = todoRepository.findDatesWithBacklogCount(userId, year, month).stream()
                 .collect(Collectors.toMap(
-                        t -> t.get("date", LocalDate.class),
+                        t -> ((Date)t.get("date")).toLocalDate(),
                         t -> ((Number) t.get("count")).intValue()
                 ));
 

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -375,7 +375,7 @@ public class TodoService {
             return PaginatedHistoryResponseDto.of(historiesPage, true);
         } else if (localDate.isEqual(LocalDate.now())) {
             Page<Todo> historiesPage = getTodayTodos(userId, page, size);
-            return PaginatedHistoryResponseDto.of(historiesPage);
+            return PaginatedHistoryResponseDto.from(historiesPage);
         }
         Page<Todo> historiesPage = todoRepository.findDeadlineBacklogs(userId, localDate, PageRequest.of(page, size));
         return PaginatedHistoryResponseDto.of(historiesPage, false);
@@ -420,7 +420,7 @@ public class TodoService {
 
         historyCountByDate.putAll(backlogCountByDate);
 
-        return HistoryCalendarListResponseDto.of(historyCountByDate);
+        return HistoryCalendarListResponseDto.from(historyCountByDate);
     }
 
     /**

--- a/src/main/java/server/poptato/todo/application/response/HistoryCalendarListResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryCalendarListResponseDto.java
@@ -9,9 +9,9 @@ public record HistoryCalendarListResponseDto(
         List<HistoryCalendarResponseDto> historyCalendarList
 ) {
 
-    public static HistoryCalendarListResponseDto of(Map<LocalDate, Integer> dates) {
+    public static HistoryCalendarListResponseDto from(Map<LocalDate, Integer> dates) {
         List<HistoryCalendarResponseDto> historyCalendarList = dates.entrySet().stream()
-                .map(entry -> new HistoryCalendarResponseDto(entry.getKey(), entry.getValue()))
+                .map(entry -> HistoryCalendarResponseDto.of(entry.getKey(), entry.getValue()))
                 .toList();
 
         return new HistoryCalendarListResponseDto(historyCalendarList);

--- a/src/main/java/server/poptato/todo/application/response/HistoryCalendarListResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryCalendarListResponseDto.java
@@ -2,12 +2,18 @@ package server.poptato.todo.application.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public record HistoryCalendarListResponseDto(
-        List<LocalDate> dates
+        List<HistoryCalendarResponseDto> historyCalendarList
 ) {
 
-    public static HistoryCalendarListResponseDto of(List<LocalDate> dates) {
-        return new HistoryCalendarListResponseDto(dates);
+    public static HistoryCalendarListResponseDto of(Map<LocalDate, Integer> dates) {
+        List<HistoryCalendarResponseDto> historyCalendarList = dates.entrySet().stream()
+                .map(entry -> new HistoryCalendarResponseDto(entry.getKey(), entry.getValue()))
+                .toList();
+
+        return new HistoryCalendarListResponseDto(historyCalendarList);
     }
 }

--- a/src/main/java/server/poptato/todo/application/response/HistoryCalendarResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryCalendarResponseDto.java
@@ -1,0 +1,9 @@
+package server.poptato.todo.application.response;
+
+import java.time.LocalDate;
+
+public record HistoryCalendarResponseDto(
+        LocalDate localDate,
+        int count
+) {
+}

--- a/src/main/java/server/poptato/todo/application/response/HistoryCalendarResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryCalendarResponseDto.java
@@ -6,4 +6,8 @@ public record HistoryCalendarResponseDto(
         LocalDate localDate,
         int count
 ) {
+
+    public static HistoryCalendarResponseDto of(LocalDate localDate, int count) {
+        return new HistoryCalendarResponseDto(localDate, count);
+    }
 }

--- a/src/main/java/server/poptato/todo/application/response/HistoryResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryResponseDto.java
@@ -9,7 +9,7 @@ public record HistoryResponseDto(
         Boolean isCompleted
 ) {
 
-    public static HistoryResponseDto of(Todo todo) {
+    public static HistoryResponseDto from(Todo todo) {
         return new HistoryResponseDto(todo.getId(), todo.getContent(), todo.getTodayStatus().equals(TodayStatus.COMPLETED));
     }
 

--- a/src/main/java/server/poptato/todo/application/response/HistoryResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryResponseDto.java
@@ -1,13 +1,19 @@
 package server.poptato.todo.application.response;
 
 import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.value.TodayStatus;
 
 public record HistoryResponseDto(
         Long todoId,
-        String content
+        String content,
+        Boolean isCompleted
 ) {
 
     public static HistoryResponseDto of(Todo todo) {
-        return new HistoryResponseDto(todo.getId(), todo.getContent());
+        return new HistoryResponseDto(todo.getId(), todo.getContent(), todo.getTodayStatus().equals(TodayStatus.COMPLETED));
+    }
+
+    public static HistoryResponseDto of(Todo todo, Boolean isCompleted) {
+        return new HistoryResponseDto(todo.getId(), todo.getContent(), isCompleted);
     }
 }

--- a/src/main/java/server/poptato/todo/application/response/PaginatedHistoryResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/PaginatedHistoryResponseDto.java
@@ -9,9 +9,9 @@ public record PaginatedHistoryResponseDto(
         List<HistoryResponseDto> histories,
         int totalPageCount
 ) {
-    public static PaginatedHistoryResponseDto of(Page<Todo> todosPage) {
+    public static PaginatedHistoryResponseDto from(Page<Todo> todosPage) {
         List<HistoryResponseDto> histories = todosPage.getContent().stream()
-                .map(HistoryResponseDto::of)
+                .map(HistoryResponseDto::from)
                 .toList();
 
         return new PaginatedHistoryResponseDto(histories, todosPage.getTotalPages());

--- a/src/main/java/server/poptato/todo/application/response/PaginatedHistoryResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/PaginatedHistoryResponseDto.java
@@ -16,4 +16,12 @@ public record PaginatedHistoryResponseDto(
 
         return new PaginatedHistoryResponseDto(histories, todosPage.getTotalPages());
     }
+
+    public static PaginatedHistoryResponseDto of(Page<Todo> todosPage, Boolean isCompleted) {
+        List<HistoryResponseDto> histories = todosPage.getContent().stream()
+                .map((Todo todo) -> HistoryResponseDto.of(todo, isCompleted))
+                .toList();
+
+        return new PaginatedHistoryResponseDto(histories, todosPage.getTotalPages());
+    }
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -32,6 +32,12 @@ public interface TodoRepository {
 
     Integer findMaxBacklogOrderByUserIdOrZero(Long userId);
 
+    default Page<Todo> findDeadlineBacklogs(Long userId, LocalDate localDate, Pageable pageable) {
+        return findDeadlineBacklogsByUserIdAndLocalDate(userId, localDate, pageable);
+    }
+
+    Page<Todo> findDeadlineBacklogsByUserIdAndLocalDate(Long userId, LocalDate localDate, Pageable pageable);
+
     default List<Todo> findIncompleteTodays(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus) {
         return findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(
                 userId, type, todayDate, todayStatus);
@@ -47,6 +53,8 @@ public interface TodoRepository {
     }
 
     Page<Todo> findTodosByUserIdAndCompletedDateTime(Long userId, LocalDate localDate, Pageable pageable);
+
+
 
     List<Todo> findByType(Type type);
 
@@ -80,4 +88,6 @@ public interface TodoRepository {
      * @return 해당 연도-월 조회 일 기준 미래 날짜중 마감일이 정해진 백로그가 있는 날짜와 백로그 개수 목록
      */
     List<Tuple> findDatesWithBacklogCount(Long userId, String year, int month);
+
+
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -1,5 +1,6 @@
 package server.poptato.todo.domain.repository;
 
+import jakarta.persistence.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
@@ -70,4 +71,13 @@ public interface TodoRepository {
      * @return 미완료된 어제의 할 일 목록
      */
     List<Todo> findIncompleteYesterdays(Long userId);
+
+    /**
+     *
+     * @param userId 사용자 ID
+     * @param year 해당 연도
+     * @param month 해당 월
+     * @return 해당 연도-월 조회 일 기준 미래 날짜중 마감일이 정해진 백로그가 있는 날짜와 백로그 개수 목록
+     */
+    List<Tuple> findDatesWithBacklogCount(Long userId, String year, int month);
 }

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -85,15 +85,25 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
             @Param("todayDate") LocalDate todayDate
     );
 
-    @Query("SELECT t FROM Todo t " +
-            "WHERE t.id IN (" +
-            "    SELECT c.todoId FROM CompletedDateTime c " +
-            "    WHERE DATE(c.dateTime) = :localDate" +
-            ") AND t.userId = :userId " +
-            "ORDER BY (" +
-            "    SELECT c.dateTime FROM CompletedDateTime c " +
-            "    WHERE c.todoId = t.id AND DATE(c.dateTime) = :localDate" +
-            ") ASC")
+
+    @Query("""
+            SELECT t
+            FROM Todo t
+            WHERE userId = :userId
+              AND deadline = :localDate
+              AND type IN ('BACKLOG', 'YESTERDAY')
+            """)
+    Page<Todo> findDeadlineBacklogsByUserIdAndLocalDate(Long userId, LocalDate localDate, Pageable pageable);
+
+        @Query("SELECT t FROM Todo t " +
+                "WHERE t.id IN (" +
+                "    SELECT c.todoId FROM CompletedDateTime c " +
+                "    WHERE DATE(c.dateTime) = :localDate" +
+                ") AND t.userId = :userId " +
+                "ORDER BY (" +
+                "    SELECT c.dateTime FROM CompletedDateTime c " +
+                "    WHERE c.todoId = t.id AND DATE(c.dateTime) = :localDate" +
+                ") ASC")
     Page<Todo> findTodosByUserIdAndCompletedDateTime(@Param("userId") Long userId,
                                                      @Param("localDate") LocalDate localDate, Pageable pageable);
 

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -1,5 +1,6 @@
 package server.poptato.todo.infra.repository;
 
+import jakarta.persistence.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -125,4 +126,18 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
     @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.type = 'YESTERDAY' " +
             "AND t.todayStatus = 'INCOMPLETE' ORDER BY t.todayOrder DESC")
     List<Todo> findIncompleteYesterdays(@Param("userId") Long userId);
+
+    @Query(value = """
+    SELECT t.deadline AS date, COUNT(*) AS count
+    FROM todo t
+    WHERE t.user_id = :userId
+      AND t.deadline IS NOT NULL
+      AND t.deadline > CURDATE()
+      AND YEAR(t.deadline) = :year
+      AND MONTH(t.deadline) = :month
+      AND t.type = 'BACKLOG'
+    GROUP BY t.deadline
+    ORDER BY t.deadline
+    """, nativeQuery = true)
+    List<Tuple> findDatesWithBacklogCount(Long userId, String year, int month);
 }

--- a/src/test/java/server/poptato/todo/api/TodoControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoControllerTest.java
@@ -18,6 +18,7 @@ import server.poptato.configuration.ControllerTestConfig;
 import server.poptato.todo.api.request.*;
 import server.poptato.todo.application.TodoService;
 import server.poptato.todo.application.response.HistoryCalendarListResponseDto;
+import server.poptato.todo.application.response.HistoryCalendarResponseDto;
 import server.poptato.todo.application.response.PaginatedHistoryResponseDto;
 import server.poptato.todo.application.response.TodoDetailResponseDto;
 import server.poptato.todo.domain.value.Type;
@@ -588,7 +589,8 @@ public class TodoControllerTest extends ControllerTestConfig {
     @DisplayName("특정 연도 및 월의 할 일 히스토리 날짜 목록을 조회한다.")
     public void getHistoryCalendarDateList() throws Exception {
         // given
-        HistoryCalendarListResponseDto response = new HistoryCalendarListResponseDto(List.of(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 15)));
+        HistoryCalendarListResponseDto response = new HistoryCalendarListResponseDto(List.of(
+                new HistoryCalendarResponseDto(LocalDate.of(2025, 1, 1), -1), new HistoryCalendarResponseDto(LocalDate.of(2025, 1, 15), -1)));
 
         Mockito.when(jwtService.extractUserIdFromToken(token)).thenReturn(1L);
         Mockito.when(todoService.getHistoriesCalendar(anyLong(), anyString(), anyInt()))
@@ -626,7 +628,9 @@ public class TodoControllerTest extends ControllerTestConfig {
                                                 fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                                                 fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                                                fieldWithPath("result.dates").type(JsonFieldType.ARRAY).description("히스토리가 있는 날짜 목록 (YYYY-MM-DD)")
+                                                fieldWithPath("result.historyCalendarList").type(JsonFieldType.ARRAY).description("히스토리/백로그 날짜 및 개수 목록"),
+                                                fieldWithPath("result.historyCalendarList[].localDate").type(JsonFieldType.STRING).description("날짜 (YYYY-MM-DD)"),
+                                                fieldWithPath("result.historyCalendarList[].count").type(JsonFieldType.NUMBER).description("해당 날짜의 할 일 수, 히스토리가 있는 경우 -1")
                                         )
                                         .responseSchema(Schema.schema("HistoryCalendarListResponse"))
                                         .build()


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- calendar 조회시 오늘, 이전 날 중 완료한 데이터가 있는 날은 날짜와 함께 -1을 반환하도록 하였고, 미래 날짜에 대해서 마감기한이 정해진 백로그가 있는 날짜와 백로그 개수를 반환하도록 구현하였습니다.
<img width="287" alt="response" src="https://github.com/user-attachments/assets/aac3af3d-a4b9-4d28-9c81-1cf63ee514af" />

- 각 날짜에 대해 history조회시 과거, 오늘, 미래로 구분하여 유형에 맞게 
  과거 - 완료한 할일, 완료 여부=true
  오늘 - 오늘 할일, 완료 여부==today_status인지
  미래 - 마감기한이 정해진 할일, 완료 여부=false를 반환하도록 구현하였습니다. 
  오늘 할 일에 대해 기존에는 완료된 할 일만 보여주는 방식이어서 완료 여부 변수를 추가했습니다. 과거, 오늘 , 미래 형식을 통합하기위해 각각 true 와 false를 반환하도록 설정을 했는데 혹시 다른 좋은 방식이 있다면 피드백 부탁드립니다.
<img width="394" alt="과거히스토리조회" src="https://github.com/user-attachments/assets/1c91e90d-93ec-4813-8f15-4c9cf599b7f9" />
<img width="374" alt="오늘히스토리조회" src="https://github.com/user-attachments/assets/2be90d49-a737-4708-9d91-4303d91aabc0" />
<img width="325" alt="미래히스토리조회" src="https://github.com/user-attachments/assets/f9a15393-1be1-465b-9a10-fb593257c5ef" />


api테스트 진행 완료했고 테스트 코드도 수정 완료했습니다.
---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

ex)
- Resolves : #76 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
