### PR TITLE
[feat] : API 버저닝 및 도커 빌드 캐시 파일을 정리한다

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -42,7 +42,6 @@ if [ -z "$IS_GREEN" ]; then
     exit 1
   }
 
-  # Health check 타임아웃: 60초
   SECONDS=0
   while true; do
     echo ">>> 2. green health check 중..."
@@ -74,6 +73,9 @@ if [ -z "$IS_GREEN" ]; then
   echo ">>> 5. 불필요한 Docker 이미지 삭제 중..."
   sudo docker image prune -f
 
+  echo ">>> 6. Docker 빌드 캐시를 정리합니다."
+  sudo docker builder prune -f --filter "until=24h"
+
   send_discord_message "$MESSAGE_SUCCESS"
 
 # 💙 green이 실행중이면 blue를 up합니다.
@@ -86,7 +88,6 @@ else
     exit 1
   }
 
-  # Health check 타임아웃: 60초
   SECONDS=0
   while true; do
     echo ">>> 2. blue health check 중..."
@@ -117,6 +118,9 @@ else
 
   echo ">>> 5. 불필요한 Docker 이미지 삭제 중..."
   sudo docker image prune -f
+
+  echo ">>> 6. Docker 빌드 캐시를 정리합니다."
+  sudo docker builder prune -f --filter "until=24h"
 
   send_discord_message "$MESSAGE_SUCCESS"
 fi


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

## 1. API 버저닝

### 🚨 문제

- 기존 DTO 및 응답 값이 변화함에 따라, 업데이트를 하지 않는 유저는 오류가 발생할 수 있는 문제가 있었습니다.

### ✅ 해결

- 헤더에 버전 값을 받아 API를 다르게 호출하며 해결하였습니다.
- 엔드포인트 자체는 동일하나, 버전 값에 따라서 분기됩니다.
- 이에 따라 내부 비즈니스 로직과 DTO가 달라져서 이전 버전 & 최신 버전을 이용할 수 있습니다.

### 🌈 결과

> 스웨거에서 버전 값 설정 가능

<img width="804" alt="스크린샷 2025-04-10 오후 1 05 51" src="https://github.com/user-attachments/assets/94307c55-46b9-415b-a50e-60a67109a96f" />

> 구버전(1.0)을 호출한 경우

<img width="1461" alt="스크린샷 2025-04-10 오후 1 05 17" src="https://github.com/user-attachments/assets/bb7a874e-a654-4e8f-b2ae-69d3af2ef9d3" />

> 신버전(2.0)을 호출한 경우

<img width="1451" alt="스크린샷 2025-04-10 오후 1 05 28" src="https://github.com/user-attachments/assets/6180bd9a-ff43-40ae-bee3-37e3e19b2140" />

---

## 2. 테스트 서버 배포 실패 문제 해결

### 🚨 문제

- 인스턴스에 접속하여 디스크 용량을 확인해 보니, 100%로 꽉차 있는 것을 발견했습니다.
- 배포 성공 이후 미사용 도커 이미지를 모두 제거하는 로직이 존재하기 때문에 해당 부분에서 문제가 없을 것이라고 생각했지만, `도커 빌드 캐시`가 누적되어 4.2GB나 차지하고 있었습니다.

### ✅ 해결

- 때문에 해당 캐시를 제거하였고, 24시간이 지난 캐시 파일은 배포 이후 제거하도록 스크립트에 추가하였습니다.

```
  echo ">>> 6. Docker 빌드 캐시를 정리합니다."
  sudo docker builder prune -f --filter "until=24h"
```

### 🌈 결과

<img width="676" alt="스크린샷 2025-04-10 오후 5 42 15" src="https://github.com/user-attachments/assets/4dbd8f64-08ab-4710-9833-12491e4f6945" />

<img width="442" alt="스크린샷 2025-04-10 오후 5 42 36" src="https://github.com/user-attachments/assets/69ce31db-d28c-448a-b5fe-7f1313da69c1" />

- 삭제 이후 4.2GB의 캐시 파일이 정리되었고, 디스크 용량도 정상화 되었습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #79 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

- 웹에서는 이런 경우가 없어서 저도 이번에 처음 해 보는 작업이었습니다!
- 앞으로 DTO 등 응답 값에 변화가 갈 수 있는 작업은 최대한 지양해야 할 것 같습니다. 불가피하다면 이번 처럼 헤더에 버전 값을 추가해야할 듯 합니다.
- [버저닝 참고한 블로그](https://joecp17.tistory.com/84)
- 추가적으로, 현재 API 2개가 스웨거에 혼재할 수가 없어서 v1의 테스트코드는 임시 주석처리 해 둔 상황입니다. (추후 고칠 예정)

