### PR TITLE
[feat] : 오늘, 할일 페이지에 카테고리 정보를 추가한다

### DIFF
--- a/src/main/java/server/poptato/category/api/CategoryController.java
+++ b/src/main/java/server/poptato/category/api/CategoryController.java
@@ -1,5 +1,8 @@
 package server.poptato.category.api;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -50,14 +53,20 @@ public class CategoryController {
      * @param mobileType 클라이언트 운영체제
      * @param page 요청 페이지 번호 (기본값: 0)
      * @param size 한 페이지당 항목 수 (기본값: 6)
+     * @param mobileType 클라이언트의 모바일 타입
      * @return 카테고리 목록과 페이징 정보를 포함한 응답
      */
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<CategoryListResponseDto>> getCategories(
             @RequestHeader("Authorization") String authorizationHeader,
-            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "6") int size
+            @RequestParam(value = "size", defaultValue = "6") int size,
+            @Parameter(name = "X-Mobile-Type", in = ParameterIn.HEADER,
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {"ANDROID", "IOS"}
+                    )
+            ) MobileType mobileType
     ) {
         CategoryListResponseDto response = categoryService.getCategories(jwtService.extractUserIdFromToken(authorizationHeader), mobileType, page, size);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);

--- a/src/main/java/server/poptato/category/domain/entity/Category.java
+++ b/src/main/java/server/poptato/category/domain/entity/Category.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import server.poptato.category.api.request.CategoryCreateUpdateRequestDto;
+import server.poptato.emoji.domain.entity.Emoji;
 
 import java.time.LocalDateTime;
 
@@ -24,6 +25,7 @@ public class Category {
     @NotNull
     private Long userId;
     @NotNull
+    @Column(name = "emoji_id")
     private Long emojiId;
     @NotNull
     private int categoryOrder;
@@ -34,6 +36,9 @@ public class Category {
     private LocalDateTime createDate;
     @LastModifiedDate
     private LocalDateTime modifyDate;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emoji_id", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Emoji emoji;
 
     public static Category create(Long userId, int maxCategoryId, CategoryCreateUpdateRequestDto request) {
         return Category.builder()

--- a/src/main/java/server/poptato/emoji/api/controller/EmojiController.java
+++ b/src/main/java/server/poptato/emoji/api/controller/EmojiController.java
@@ -1,5 +1,8 @@
 package server.poptato.emoji.api.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,16 +24,21 @@ public class EmojiController {
      *
      * 사용 가능한 이모지 목록을 페이지네이션 형식으로 조회합니다.
      *
-     * @param mobileType 클라이언트 운영체제
      * @param page 요청 페이지 번호 (기본값: 0)
      * @param size 한 페이지당 항목 수 (기본값: 70)
+     * @param mobileType 클라이언트의 모바일 타입
      * @return 그룹화된 이모지 목록과 페이징 정보를 포함한 응답
      */
     @GetMapping
     public ResponseEntity<ApiResponse<EmojiResponseDto>> getCategories(
-            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "70") int size
+            @RequestParam(value = "size", defaultValue = "70") int size,
+            @Parameter(name = "X-Mobile-Type", in = ParameterIn.HEADER,
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {"ANDROID", "IOS"}
+                    )
+            ) MobileType mobileType
     ) {
         EmojiResponseDto response = emojiService.getGroupedEmojis(mobileType, page, size);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);

--- a/src/main/java/server/poptato/global/config/WebConfig.java
+++ b/src/main/java/server/poptato/global/config/WebConfig.java
@@ -3,10 +3,13 @@ package server.poptato.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import server.poptato.global.convertor.StringToMobileTypeConvertor;
+import server.poptato.global.resolver.MobileTypeArgumentResolver;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -25,5 +28,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new StringToMobileTypeConvertor());
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MobileTypeArgumentResolver());
     }
 }

--- a/src/main/java/server/poptato/global/resolver/MobileTypeArgumentResolver.java
+++ b/src/main/java/server/poptato/global/resolver/MobileTypeArgumentResolver.java
@@ -1,0 +1,32 @@
+package server.poptato.global.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import server.poptato.global.exception.CustomException;
+import server.poptato.global.response.status.ErrorStatus;
+import server.poptato.user.domain.value.MobileType;
+
+public class MobileTypeArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType() == MobileType.class;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String header = webRequest.getHeader("X-Mobile-Type");
+
+        if (header == null) {
+            throw new CustomException(ErrorStatus._INVALID_HEADER_VALUE);
+        }
+
+        try {
+            return MobileType.valueOf(header.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorStatus._INVALID_HEADER_VALUE);
+        }
+    }
+}

--- a/src/main/java/server/poptato/global/resolver/MobileTypeArgumentResolver.java
+++ b/src/main/java/server/poptato/global/resolver/MobileTypeArgumentResolver.java
@@ -20,7 +20,7 @@ public class MobileTypeArgumentResolver implements HandlerMethodArgumentResolver
         String header = webRequest.getHeader("X-Mobile-Type");
 
         if (header == null) {
-            throw new CustomException(ErrorStatus._INVALID_HEADER_VALUE);
+            return MobileType.ANDROID;
         }
 
         try {

--- a/src/main/java/server/poptato/global/response/status/ErrorStatus.java
+++ b/src/main/java/server/poptato/global/response/status/ErrorStatus.java
@@ -17,7 +17,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL-405", "허용되지 않은 요청 메소드입니다."),
     _UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "GLOBAL-415", "지원되지 않는 미디어 타입입니다."),
     _NOT_FOUND_HANDLER(HttpStatus.NOT_FOUND, "GLOBAL-404", "해당 경로에 대한 핸들러를 찾을 수 없습니다."),
-    _FAILED_TRANSLATE_SWAGGER(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL-500", "Rest Docs로 생성된 json파일을 통한 스웨거 변환에 실패하였습니다.")
+    _FAILED_TRANSLATE_SWAGGER(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL-500", "Rest Docs로 생성된 json파일을 통한 스웨거 변환에 실패하였습니다."),
+    _INVALID_HEADER_VALUE(HttpStatus.BAD_REQUEST, "GLOBAL-400", "요청 헤더에 올바르지 않은 값이 포함되어 있습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/server/poptato/todo/api/TodoBacklogController.java
+++ b/src/main/java/server/poptato/todo/api/TodoBacklogController.java
@@ -10,6 +10,7 @@ import server.poptato.todo.application.TodoBacklogService;
 import server.poptato.todo.application.response.*;
 import server.poptato.global.response.ApiResponse;
 import server.poptato.global.response.status.SuccessStatus;
+import server.poptato.user.domain.value.MobileType;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,10 +35,11 @@ public class TodoBacklogController {
     public ResponseEntity<ApiResponse<BacklogListResponseDto>> getBacklogList(
             @RequestHeader("Authorization") String authorizationHeader,
             @RequestParam(value = "category") Long categoryId,
+            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "8") int size
     ) {
-        BacklogListResponseDto response = todoBacklogService.getBacklogList(jwtService.extractUserIdFromToken(authorizationHeader), categoryId, page, size);
+        BacklogListResponseDto response = todoBacklogService.getBacklogList(jwtService.extractUserIdFromToken(authorizationHeader), categoryId, mobileType, page, size);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 

--- a/src/main/java/server/poptato/todo/api/TodoBacklogController.java
+++ b/src/main/java/server/poptato/todo/api/TodoBacklogController.java
@@ -1,5 +1,8 @@
 package server.poptato.todo.api;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -29,15 +32,22 @@ public class TodoBacklogController {
      * @param categoryId 조회할 카테고리 ID
      * @param page 요청 페이지 번호 (기본값: 0)
      * @param size 한 페이지당 항목 수 (기본값: 8)
+     * @param mobileType 클라이언트의 모바일 타입
      * @return 백로그 목록 및 페이징 정보
      */
-    @GetMapping("/backlogs")
+    @GetMapping(value = "/backlogs")
     public ResponseEntity<ApiResponse<BacklogListResponseDto>> getBacklogList(
             @RequestHeader("Authorization") String authorizationHeader,
             @RequestParam(value = "category") Long categoryId,
-            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "8") int size
+            @RequestParam(value = "size", defaultValue = "8") int size,
+            @Parameter(name = "X-Mobile-Type", in = ParameterIn.HEADER,
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {"ANDROID", "IOS"}
+                    )
+            ) MobileType mobileType
+
     ) {
         BacklogListResponseDto response = todoBacklogService.getBacklogList(jwtService.extractUserIdFromToken(authorizationHeader), categoryId, mobileType, page, size);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);

--- a/src/main/java/server/poptato/todo/api/TodoController.java
+++ b/src/main/java/server/poptato/todo/api/TodoController.java
@@ -1,5 +1,8 @@
 package server.poptato.todo.api;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -107,13 +110,19 @@ public class TodoController {
      * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
      * @param mobileType 클라이언트 운영체제
      * @param todoId 조회할 할 일 ID
+     * @param mobileType 클라이언트의 모바일 타입
      * @return 할 일 상세 정보
      */
     @GetMapping("/todo/{todoId}")
     public ResponseEntity<ApiResponse<TodoDetailResponseDto>> getTodoInfo(
             @RequestHeader("Authorization") String authorizationHeader,
-            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
-            @PathVariable Long todoId
+            @PathVariable Long todoId,
+            @Parameter(name = "X-Mobile-Type", in = ParameterIn.HEADER,
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {"ANDROID", "IOS"}
+                    )
+            ) MobileType mobileType
     ) {
         TodoDetailResponseDto response = todoService.getTodoInfo(jwtService.extractUserIdFromToken(authorizationHeader), mobileType, todoId);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);

--- a/src/main/java/server/poptato/todo/api/TodoTodayController.java
+++ b/src/main/java/server/poptato/todo/api/TodoTodayController.java
@@ -1,5 +1,8 @@
 package server.poptato.todo.api;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,14 +34,20 @@ public class TodoTodayController {
      * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
      * @param page 요청 페이지 번호 (기본값: 0)
      * @param size 한 페이지당 항목 수 (기본값: 8)
+     * @param mobileType 클라이언트의 모바일 타입
      * @return 오늘의 할 일 목록 및 페이징 정보
      */
     @GetMapping("/todays")
     public ResponseEntity<ApiResponse<TodayListResponseDto>> getTodayList(
             @RequestHeader("Authorization") String authorizationHeader,
-            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "8") int size
+            @RequestParam(value = "size", defaultValue = "8") int size,
+            @Parameter(name = "X-Mobile-Type", in = ParameterIn.HEADER,
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {"ANDROID", "IOS"}
+                    )
+            ) MobileType mobileType
     ) {
         LocalDate todayDate = LocalDate.now();
         // 오늘의 할 일 목록 조회

--- a/src/main/java/server/poptato/todo/api/TodoTodayController.java
+++ b/src/main/java/server/poptato/todo/api/TodoTodayController.java
@@ -11,6 +11,7 @@ import server.poptato.todo.application.TodoTodayService;
 import server.poptato.todo.application.response.TodayListResponseDto;
 import server.poptato.global.response.ApiResponse;
 import server.poptato.global.response.status.SuccessStatus;
+import server.poptato.user.domain.value.MobileType;
 
 import java.time.LocalDate;
 
@@ -35,6 +36,7 @@ public class TodoTodayController {
     @GetMapping("/todays")
     public ResponseEntity<ApiResponse<TodayListResponseDto>> getTodayList(
             @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(value = "mobileType", defaultValue = "ANDROID") MobileType mobileType,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "8") int size
     ) {
@@ -42,6 +44,7 @@ public class TodoTodayController {
         // 오늘의 할 일 목록 조회
         TodayListResponseDto response = todoTodayService.getTodayList(
                 jwtService.extractUserIdFromToken(authorizationHeader),
+                mobileType,
                 page,
                 size,
                 todayDate

--- a/src/main/java/server/poptato/todo/application/TodoBacklogService.java
+++ b/src/main/java/server/poptato/todo/application/TodoBacklogService.java
@@ -16,6 +16,7 @@ import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.repository.TodoRepository;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
+import server.poptato.user.domain.value.MobileType;
 import server.poptato.user.validator.UserValidator;
 
 import java.util.Objects;
@@ -42,12 +43,12 @@ public class TodoBacklogService {
      * @param size 페이지 크기
      * @return 백로그 목록과 페이징 정보
      */
-    public BacklogListResponseDto getBacklogList(Long userId, Long categoryId, int page, int size) {
+    public BacklogListResponseDto getBacklogList(Long userId, Long categoryId, MobileType mobileType, int page, int size) {
         userValidator.checkIsExistUser(userId);
         categoryValidator.validateCategory(userId, categoryId);
         Page<Todo> backlogs = getBacklogsPagination(userId, categoryId, page, size);
         String categoryName = categoryRepository.findById(categoryId).get().getName();
-        return BacklogListResponseDto.of(categoryName, backlogs);
+        return BacklogListResponseDto.of(categoryName, mobileType, backlogs);
     }
 
     /**

--- a/src/main/java/server/poptato/todo/application/TodoTodayService.java
+++ b/src/main/java/server/poptato/todo/application/TodoTodayService.java
@@ -3,11 +3,13 @@ package server.poptato.todo.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.poptato.category.application.response.CategoryResponseDto;
 import server.poptato.todo.application.response.TodayListResponseDto;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.repository.TodoRepository;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
+import server.poptato.user.domain.value.MobileType;
 import server.poptato.user.validator.UserValidator;
 
 import java.time.LocalDate;
@@ -30,14 +32,14 @@ public class TodoTodayService {
      * @param todayDate 오늘 날짜
      * @return TodayListResponseDto 오늘의 할 일 목록과 페이지 정보
      */
-    public TodayListResponseDto getTodayList(long userId, int page, int size, LocalDate todayDate) {
+    public TodayListResponseDto getTodayList(long userId, MobileType mobileType, int page, int size, LocalDate todayDate) {
         userValidator.checkIsExistUser(userId);
 
         List<Todo> todays = getAllTodays(userId, todayDate);
         List<Todo> todaySubList = getTodayPagination(todays, page, size);
         int totalPageCount = (int) Math.ceil((double) todays.size() / size);
 
-        return TodayListResponseDto.of(todayDate, todaySubList, totalPageCount);
+        return TodayListResponseDto.of(todayDate, mobileType, todaySubList, totalPageCount);
     }
 
     /**
@@ -69,8 +71,8 @@ public class TodoTodayService {
      */
     private List<Todo> getAllTodays(long userId, LocalDate todayDate) {
         List<Todo> todays = new ArrayList<>();
-        List<Todo> incompleteTodos = todoRepository.findIncompleteTodays(userId, Type.TODAY, todayDate, TodayStatus.INCOMPLETE);
-        List<Todo> completedTodos = todoRepository.findCompletedTodays(userId, todayDate);
+        List<Todo> incompleteTodos = todoRepository.findIncompleteTodaysWithCategory(userId, Type.TODAY, todayDate, TodayStatus.INCOMPLETE);
+        List<Todo> completedTodos = todoRepository.findCompletedTodaysWithCategory(userId, todayDate);
 
         todays.addAll(incompleteTodos);
         todays.addAll(completedTodos);

--- a/src/main/java/server/poptato/todo/application/response/BacklogListResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/BacklogListResponseDto.java
@@ -1,9 +1,14 @@
 package server.poptato.todo.application.response;
 
 import org.springframework.data.domain.Page;
+import server.poptato.category.domain.entity.Category;
+import server.poptato.emoji.domain.entity.Emoji;
+import server.poptato.global.util.FileUtil;
 import server.poptato.todo.domain.entity.Todo;
+import server.poptato.user.domain.value.MobileType;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public record BacklogListResponseDto(
@@ -13,12 +18,24 @@ public record BacklogListResponseDto(
         int totalPageCount
 ){
 
-    public static BacklogListResponseDto of (String categoryName, Page<Todo> backlogs) {
+    public static BacklogListResponseDto of(String categoryName, MobileType mobileType, Page<Todo> backlogs) {
         return new BacklogListResponseDto(
                 backlogs.getTotalElements(),
                 categoryName,
                 backlogs.getContent().stream()
-                        .map(BacklogResponseDto::from)
+                        .map((backlog) -> {
+                            Category category = backlog.getCategory();
+                            String detailCategoryName = Optional.ofNullable(category)
+                                    .map(Category::getName)
+                                    .orElse(null);
+                            String imageUrl = Optional.ofNullable(category)
+                                    .map(Category::getEmoji)
+                                    .map(Emoji::getImageUrl)
+                                    .map((url) -> FileUtil.changeFileExtension(url, mobileType.getImageUrlExtension()))
+                                    .orElse(null);
+
+                            return BacklogResponseDto.of(backlog, detailCategoryName, imageUrl);
+                        })
                         .collect(Collectors.toList()),
                 backlogs.getTotalPages()
         );

--- a/src/main/java/server/poptato/todo/application/response/BacklogResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/BacklogResponseDto.java
@@ -11,10 +11,12 @@ public record BacklogResponseDto(
         Boolean isBookmark,
         Boolean isRepeat,
         Integer dDay,
-        LocalDate deadline
+        LocalDate deadline,
+        String detailCategoryName,
+        String imageUrl
 ) {
 
-    public static BacklogResponseDto from(Todo todo) {
+    public static BacklogResponseDto of(Todo todo, String detailCategoryName, String imageUrl) {
         LocalDate today = LocalDate.now();
         Integer dDay = null;
 
@@ -28,7 +30,9 @@ public record BacklogResponseDto(
                 todo.isBookmark(),
                 todo.isRepeat(),
                 dDay,
-                todo.getDeadline()
+                todo.getDeadline(),
+                detailCategoryName,
+                imageUrl
         );
     }
 }

--- a/src/main/java/server/poptato/todo/application/response/TodayListResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/TodayListResponseDto.java
@@ -1,9 +1,14 @@
 package server.poptato.todo.application.response;
 
+import server.poptato.category.domain.entity.Category;
+import server.poptato.emoji.domain.entity.Emoji;
+import server.poptato.global.util.FileUtil;
 import server.poptato.todo.domain.entity.Todo;
+import server.poptato.user.domain.value.MobileType;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public record TodayListResponseDto(
@@ -11,11 +16,23 @@ public record TodayListResponseDto(
         List<TodayResponseDto> todays,
         int totalPageCount
 ) {
-    public static TodayListResponseDto of(LocalDate date, List<Todo> todos, int totalPageCount) {
+    public static TodayListResponseDto of(LocalDate date, MobileType mobileType, List<Todo> todos, int totalPageCount) {
         return new TodayListResponseDto(
                 date,
                 todos.stream()
-                        .map(TodayResponseDto::of)
+                        .map((todo) -> {
+                            Category category = todo.getCategory();
+                            String name = Optional.ofNullable(category)
+                                    .map(Category::getName)
+                                    .orElse(null);
+                            String imageUrl = Optional.ofNullable(category)
+                                    .map(Category::getEmoji)
+                                    .map(Emoji::getImageUrl)
+                                    .map((url) -> FileUtil.changeFileExtension(url, mobileType.getImageUrlExtension()))
+                                    .orElse(null);
+
+                            return TodayResponseDto.of(todo, name, imageUrl);
+                        })
                         .collect(Collectors.toList()),
                 totalPageCount
         );

--- a/src/main/java/server/poptato/todo/application/response/TodayResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/TodayResponseDto.java
@@ -13,9 +13,11 @@ public record TodayResponseDto(
         Boolean isBookmark,
         Boolean isRepeat,
         Integer dDay,
-        LocalDate deadline
+        LocalDate deadline,
+        String categoryName,
+        String imageUrl
 ) {
-    public static TodayResponseDto of(Todo todo) {
+    public static TodayResponseDto of(Todo todo, String categoryName, String imageUrl) {
         Integer dDay = null;
         if (todo.getDeadline() != null && todo.getTodayDate() != null) {
             dDay = (int) ChronoUnit.DAYS.between(todo.getTodayDate(), todo.getDeadline());
@@ -28,7 +30,9 @@ public record TodayResponseDto(
                 todo.isBookmark(),
                 todo.isRepeat(),
                 dDay,
-                todo.getDeadline()
+                todo.getDeadline(),
+                categoryName,
+                imageUrl
         );
     }
 }

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.lang.Nullable;
+import server.poptato.category.domain.entity.Category;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
 
@@ -26,6 +27,7 @@ public class Todo {
     @NotNull
     private Long userId;
     @Nullable
+    @Column(name = "category_id")
     private Long  categoryId;
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -53,6 +55,10 @@ public class Todo {
     private LocalDateTime createDate;
     @LastModifiedDate
     private LocalDateTime modifyDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Category category;
 
     public static Todo createBacklog(Long userId, String content, Integer backlogOrder) {
         return Todo.builder()

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -16,7 +16,11 @@ public interface TodoRepository {
 
     List<Todo> findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus);
 
+    List<Todo> findIncompleteTodosWithCategory(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus);
+
     List<Todo> findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(Long userId, LocalDate todayDate);
+
+    List<Todo> findCompletedTodayByUserIdOrderByCompletedDateTimeAscWithCategory(Long userId, LocalDate todayDate);
 
     Optional<Todo> findById(Long todoId);
 
@@ -43,8 +47,18 @@ public interface TodoRepository {
                 userId, type, todayDate, todayStatus);
     }
 
+    default List<Todo> findIncompleteTodaysWithCategory(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus) {
+        return findIncompleteTodosWithCategory(
+                userId, type, todayDate, todayStatus);
+    }
+
     default List<Todo> findCompletedTodays(Long userId, LocalDate todayDate) {
         return findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(
+                userId, todayDate);
+    }
+
+    default List<Todo> findCompletedTodaysWithCategory(Long userId, LocalDate todayDate) {
+        return findCompletedTodayByUserIdOrderByCompletedDateTimeAscWithCategory(
                 userId, todayDate);
     }
 

--- a/src/test/java/server/poptato/category/api/CategoryControllerTest.java
+++ b/src/test/java/server/poptato/category/api/CategoryControllerTest.java
@@ -114,6 +114,7 @@ public class CategoryControllerTest extends ControllerTestConfig {
         ResultActions resultActions = this.mockMvc.perform(
                 RestDocumentationRequestBuilders.get("/category/list")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer sampleToken")
+                        .header("X-Mobile-Type", "ANDROID")
                         .param("page", "0")
                         .param("size", "6")
                         .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/server/poptato/emoji/api/EmojiControllerTest.java
+++ b/src/test/java/server/poptato/emoji/api/EmojiControllerTest.java
@@ -54,6 +54,7 @@ public class EmojiControllerTest extends ControllerTestConfig {
                 RestDocumentationRequestBuilders.get("/emojis")
                         .param("page", "0")
                         .param("size", "70")
+                        .header("X-Mobile-Type", "ANDROID")
                         .accept(MediaType.APPLICATION_JSON)
         );
 

--- a/src/test/java/server/poptato/todo/api/TodoBacklogControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoBacklogControllerTest.java
@@ -20,6 +20,7 @@ import server.poptato.todo.application.TodoBacklogService;
 import server.poptato.todo.application.response.BacklogCreateResponseDto;
 import server.poptato.todo.application.response.BacklogListResponseDto;
 import server.poptato.todo.application.response.PaginatedYesterdayResponseDto;
+import server.poptato.user.domain.value.MobileType;
 
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class TodoBacklogControllerTest extends ControllerTestConfig {
         BacklogListResponseDto response = new BacklogListResponseDto(10L, "Sample Category", List.of(), 1);
 
         Mockito.when(jwtService.extractUserIdFromToken(token)).thenReturn(1L);
-        Mockito.when(todoBacklogService.getBacklogList(anyLong(), anyLong(), anyInt(), anyInt())).thenReturn(response);
+        Mockito.when(todoBacklogService.getBacklogList(anyLong(), anyLong(), any(MobileType.class), anyInt(), anyInt())).thenReturn(response);
 
         // when
         ResultActions resultActions = this.mockMvc.perform(

--- a/src/test/java/server/poptato/todo/api/TodoBacklogControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoBacklogControllerTest.java
@@ -61,6 +61,7 @@ public class TodoBacklogControllerTest extends ControllerTestConfig {
                         .param("page", "0")
                         .param("size", "8")
                         .header(HttpHeaders.AUTHORIZATION, token)
+                        .header("X-Mobile-Type", "ANDROID")
                         .accept(MediaType.APPLICATION_JSON)
         );
 

--- a/src/test/java/server/poptato/todo/api/TodoControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoControllerTest.java
@@ -249,6 +249,7 @@ public class TodoControllerTest extends ControllerTestConfig {
         ResultActions resultActions = this.mockMvc.perform(
                 RestDocumentationRequestBuilders.get("/todo/{todoId}", 1L)
                         .header(HttpHeaders.AUTHORIZATION, token)
+                        .header("X-Mobile-Type", "ANDROID")
                         .accept(MediaType.APPLICATION_JSON)
         );
 

--- a/src/test/java/server/poptato/todo/api/TodoTodayControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoTodayControllerTest.java
@@ -61,6 +61,7 @@ public class TodoTodayControllerTest extends ControllerTestConfig {
                         .param("page", "0")
                         .param("size", "8")
                         .header(HttpHeaders.AUTHORIZATION, token)
+                        .header("X-Mobile-Type", "ANDROID")
                         .accept(MediaType.APPLICATION_JSON)
         );
 

--- a/src/test/java/server/poptato/todo/api/TodoTodayControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoTodayControllerTest.java
@@ -17,6 +17,7 @@ import server.poptato.auth.application.service.JwtService;
 import server.poptato.configuration.ControllerTestConfig;
 import server.poptato.todo.application.TodoTodayService;
 import server.poptato.todo.application.response.TodayListResponseDto;
+import server.poptato.user.domain.value.MobileType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -51,7 +52,7 @@ public class TodoTodayControllerTest extends ControllerTestConfig {
         );
 
         Mockito.when(jwtService.extractUserIdFromToken(token)).thenReturn(1L);
-        Mockito.when(todoTodayService.getTodayList(anyLong(), anyInt(), anyInt(), any(LocalDate.class)))
+        Mockito.when(todoTodayService.getTodayList(anyLong(), any(MobileType.class), anyInt(), anyInt(), any(LocalDate.class)))
                 .thenReturn(response);
 
         // when


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)
<img width="494" alt="image" src="https://github.com/user-attachments/assets/a0422aee-c700-45e1-9358-48621e4ed3c3" />

- 프론트와 얘기해서 각 할일마다 카테고리명과 이미지url을 추가하는 것으로 정하였습니다.
- Todo에 Category, Category에 Emogi를 ManyToOne 연관관계를 설정하고 @EntityGraph를 통해 
  todo에 대해 getCategory시에만 category와 emoji를 한 번에 fetch join처럼 가져오도록 하여 성능을 최적화하였습니다.

- MobileType에 대한 정보를 header를 통해 받도록 설정하였습니다. MobileTypeArgumentResolver를 통해 모바일 타입 값에 대해 검증을 진행합니다.
-  스웨거 문서용 @Paremeter를 사용하여 스웨거에서도 api테스트 진행이 가능합니다.
- 없으면 postman에서는 되는데 스웨거에서는 안돼요

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #81

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
혹시 다른 더 좋은 방식이 있다면 코멘트 부탁드립니다 !