### PR TITLE
[fix] : 오늘에서 미완료인 Todo에 대해서만 마감일자 푸쉬알림을 전송한다

### DIFF
--- a/src/main/java/server/poptato/external/firebase/application/FcmNotificationBatchService.java
+++ b/src/main/java/server/poptato/external/firebase/application/FcmNotificationBatchService.java
@@ -51,7 +51,7 @@ public class FcmNotificationBatchService {
      * @param user 알림을 보낼 대상 유저
      */
     private void sendUserDeadlineNotification(User user) {
-        List<Todo> todosDueToday = todoRepository.findTodosDueToday(user.getId(), LocalDate.now());
+        List<Todo> todosDueToday = todoRepository.findTodosDueToday(user.getId(), LocalDate.now(), TodayStatus.INCOMPLETE);
         if (!todosDueToday.isEmpty()) {
             List<Mobile> mobiles = mobileRepository.findAllByUserId(user.getId());
             for (Mobile mobile : mobiles) {

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -3,6 +3,7 @@ package server.poptato.todo.domain.repository;
 import jakarta.persistence.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.value.TodayStatus;
@@ -78,7 +79,15 @@ public interface TodoRepository {
 
     void deleteAllByCategoryId(Long categoryId);
 
-    List<Todo> findTodosDueToday(@Param("userId") Long userId, LocalDate deadline);
+    @Query("""
+    SELECT t FROM Todo t
+    WHERE t.userId = :userId
+      AND t.deadline = :deadline
+      AND t.todayStatus = :todayStatus
+    """)
+    List<Todo> findTodosDueToday(@Param("userId") Long userId,
+                                 @Param("deadline") LocalDate deadline,
+                                 @Param("todayStatus") TodayStatus todayStatus);
 
     void updateBacklogTodosToToday(@Param("today") LocalDate today,
                                    @Param("userIds") List<Long> userIds,


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제

- 8시에 마감일자 스케줄러가 작동하는데, 8시 이전에 완료 처리를 한 Todo에 대해서도 푸쉬알림이 전송되고 있었습니다.

###  ✅ 해결

- 이미 완료한 Todo에 대해서는 푸쉬알림을 보내지 않도록, `INCOMPLETE`인 Todo만 조회하여 전송하도록 변경하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #96 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
