### PR TITLE
ILLDAN-181 [feat]: prometheus monitoring 대상이 되도록 설정한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ out/
 .vscode/
 
 .gitignore.swp
+/htmlReport/

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     // Health-Check
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Micrometer Prometheus Registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // REST Docs & Swagger
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -86,7 +86,7 @@ if [ -z "$IS_GREEN" ]; then
   done
 
   # Prometheus 타겟 업데이트 (green, 9002 포트)
-    update_prometheus_target "green" "9002"
+  update_prometheus_target "green" "9002"
 
   echo ">>> 3. nginx 라우팅 변경 및 reload"
   sudo cp "$GREEN_NGINX_CONF" "$NGINX_CONF"
@@ -127,7 +127,7 @@ else
   done
 
   # Prometheus 타겟 업데이트 (blue, 9001 포트)
-    update_prometheus_target "blue" "9001"
+  update_prometheus_target "blue" "9001"
 
   echo ">>> 3. nginx 라우팅 변경 및 reload"
   sudo cp "$BLUE_NGINX_CONF" "$NGINX_CONF"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -21,10 +21,6 @@ NGINX_CONF="/home/ubuntu/nginx/nginx.conf"
 
 DOCKER_COMPOSE_FILE="/home/ubuntu/docker-compose.yaml"
 
-# 포트(관리/Actuator)
-BLUE_ACT_PORT=9001
-GREEN_ACT_PORT=9002
-
 MESSAGE_SUCCESS="✅ '일단!' 배포가 성공적으로 수행되었습니다!"
 MESSAGE_FAILURE="🚨 '일단!' 배포 과정에서 오류가 발생했습니다. 빠른 확인바랍니다."
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -59,7 +59,7 @@ EOF
     }
 
   ssh -o StrictHostKeyChecking=yes -i "$SSH_KEY_PATH" \
-    "${MONITORING_SERVER_USER}@${MONITORING_SERVER_IP}" \
+    "${MONITORING_SERVER_USER}@${MONITORING_SERVER}" \
     "jq . ${remote_home_tmp} >/dev/null 2>&1 \
       && mkdir -p \"\$(dirname \"${remote_file}\")\" \
       && install -m 644 -T ${remote_home_tmp} ${remote_file} \

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -73,7 +73,7 @@ if [ -z "$IS_GREEN" ]; then
   while true; do
     echo ">>> 2. green health check 중..."
     sleep 3
-    REQUEST=$(sudo docker exec illdan-green wget -qO- http://localhost:8085/actuator/health)
+    REQUEST=$(sudo docker exec illdan-green wget -qO- http://localhost:9001/actuator/health)
     if [[ "$REQUEST" == *"UP"* ]]; then
       echo "✅ health check success!!!"
       break
@@ -114,7 +114,7 @@ else
   while true; do
     echo ">>> 2. blue health check 중..."
     sleep 3
-    REQUEST=$(sudo docker exec illdan-blue wget -qO- http://localhost:8085/actuator/health)
+    REQUEST=$(sudo docker exec illdan-blue wget -qO- http://localhost:9001/actuator/health)
     if [[ "$REQUEST" == *"UP"* ]]; then
       echo "✅ health check success!!!"
       break

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -41,7 +41,7 @@ update_prometheus_target() {
   cat <<EOF > "$temp_target_file"
 [
   {
-    "targets": ["$PROMETHEUS_TARGET_SERVER:$port"],
+    "targets": ["${PROMETHEUS_TARGET_SERVER}:$port"],
     "labels": { "color": "$color" }
   }
 ]

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -71,7 +71,9 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
+  server:
+    port: 9001
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -72,7 +72,9 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
+  server:
+    port: 9001
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -72,7 +72,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
   server:
     port: 9001
 

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -73,6 +73,8 @@ management:
     web:
       exposure:
         include: health
+  server:
+    port: 9001
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 테스트코드 추가
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

📝 Description
Blue/Green 무중단 배포 전략을 지원하기 위해, 배포 완료 후 모니터링 대상(Prometheus Target)을 새로운 버전의 애플리케이션으로 동적으로 전환하는 기능을 추가합니다.

이를 통해 배포 파이프라인에서 자동으로 모니터링 대상을 업데이트하여, 운영 중인 서비스의 메트릭을 끊김 없이 수집할 수 있습니다.

✨ Key Changes
1. update_prometheus_target() 쉘 스크립트 함수 추가
Blue/Green 상태(color)와 포트(port)를 인자로 받아 원격 모니터링 서버의 Prometheus 타겟 설정 파일을 동적으로 업데이트하는 쉘 함수를 구현했습니다.

주요 동작 방식:

blue 또는 green 상태와 포트( 9001 | 9002)를 기반으로 로컬에 임시 targets.json 파일을 생성합니다.

scp를 사용하여 생성된 임시 파일을 원격 모니터링 서버에 안전하게 업로드합니다.

ssh를 통해 원격 서버에서 다음 명령을 실행하여 파일을 안전하게 교체합니다.

jq를 통해 업로드된 파일이 유효한 JSON 형식인지 검증합니다.

install -m 644 -T 명령어를 사용하여 원자적(atomic)으로 파일을 교체하여 타겟 정보가 일시적으로 비어있는 상태를 방지합니다.

성공 또는 실패 시 임시 파일을 모두 삭제하여 흔적을 남기지 않습니다.

2. Actuator 포트 및 외부 노출 포트 설정
애플리케이션 내부의 Actuator 포트를 9001로 고정했습니다.
일단 서비스 port와 모니터링, health check를 위한 포트 분리

Blue/Green 배포를 위해 외부 노출 포트를 다음과 같이 분리합니다.

Blue: 9001

Green: 9002

이 포트들은 외부에는 노출되지 않으며, 지정된 모니터링 서버에서만 접근 가능하도록 보안 그룹 설정 완료했습니다.

docker-compose.yml 파일도 수정 완료

3. .env 환경변수 추가
Prometheus 타겟 업데이트 스크립트에 필요한 원격 서버 정보를 .env 파일에 추가했습니다.

MONITORING_SERVER_USER: 모니터링 서버 접속 유저

MONITORING_SERVER: 모니터링 서버

SSH_KEY_PATH: 모니터링 서버 접속을 위한 SSH 비공개 키 경로

REMOTE_TARGETS_FILE_PATH: 원격 서버에 위치한 Prometheus 타겟 파일의 전체 경로

PROMETHEUS_TARGET_SERVER: Prometheus가 스크래핑할 애플리케이션 서버의 주소


## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
https://baby-care-dev.tistory.com/68

---