### PR TITLE
ILLDAN-147 [test]: Category 단위 테스트 코드를 추가한다

### DIFF
--- a/src/test/java/server/poptato/category/application/CategoryServiceTest.java
+++ b/src/test/java/server/poptato/category/application/CategoryServiceTest.java
@@ -1,0 +1,138 @@
+package server.poptato.category.application;
+
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import server.poptato.category.api.request.CategoryCreateUpdateRequestDto;
+import server.poptato.category.application.response.CategoryCreateResponseDto;
+import server.poptato.category.domain.entity.Category;
+import server.poptato.category.domain.repository.CategoryRepository;
+import server.poptato.category.status.CategoryErrorStatus;
+import server.poptato.category.validator.CategoryValidator;
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.emoji.domain.repository.EmojiRepository;
+import server.poptato.emoji.validator.EmojiValidator;
+import server.poptato.global.exception.CustomException;
+import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.user.validator.UserValidator;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+public class CategoryServiceTest extends ServiceTestConfig {
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @Mock
+    UserValidator userValidator;
+
+    @Mock
+    EmojiValidator emojiValidator;
+
+    @Mock
+    CategoryValidator categoryValidator;
+
+    @Mock
+    EmojiRepository emojiRepository;
+
+    @Mock
+    TodoRepository todoRepository;
+
+    @Captor
+    ArgumentCaptor<Category> categoryCaptor;
+
+    @InjectMocks
+    CategoryService categoryService;
+
+    @Nested
+    @DisplayName("[SCN-SVC-CATEGORY-001] 카테고리 생성(Create)")
+    class CreateCategory {
+
+        @Test
+        @DisplayName("[SCN-SVC-CATEGORY-001][TC-CREATE-001] 카테고리를 정상적으로 생성한다.")
+        void createCategory_success_incrementsOrderAndReturnsId() {
+            // given
+            Long userId = 10L;
+            Long emojiId = 77L;
+            String name = "Test";
+            CategoryCreateUpdateRequestDto requestDto = new CategoryCreateUpdateRequestDto(name, emojiId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            doNothing().when(emojiValidator).checkIsExistEmoji(emojiId);
+            when(categoryRepository.findMaxCategoryOrderByUserId(userId)).thenReturn(Optional.of(3));
+
+            Category persisted = mock(Category.class);
+            when(persisted.getId()).thenReturn(100L);
+            when(categoryRepository.save(any(Category.class))).thenReturn(persisted);
+
+            // when
+            CategoryCreateResponseDto responseDto = categoryService.createCategory(userId, requestDto);
+
+            // then
+            verify(categoryRepository).save(categoryCaptor.capture());
+            Category toSave = categoryCaptor.getValue();
+            assertThat(toSave.getUserId()).isEqualTo(userId);
+            assertThat(toSave.getEmojiId()).isEqualTo(emojiId);
+            assertThat(toSave.getName()).isEqualTo(name);
+            assertThat(toSave.getCategoryOrder()).isEqualTo(4);
+            assertThat(responseDto.categoryId()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-CATEGORY-001][TC-CREATE-002] 기본 카테고리가 존재하지 않아 예외가 발생한다.")
+        void createCategory_fail_defaultCategoryNotExist() {
+            // given
+            Long userId = 11L;
+            Long emojiId = 55L;
+            CategoryCreateUpdateRequestDto requestDto = new CategoryCreateUpdateRequestDto("Home", emojiId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            doNothing().when(emojiValidator).checkIsExistEmoji(emojiId);
+            when(categoryRepository.findMaxCategoryOrderByUserId(userId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> categoryService.createCategory(userId, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(CategoryErrorStatus._DEFAULT_CATEGORY_NOT_EXIST.getMessage());
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-CATEGORY-001][TC-CREATE-003] 요청한 이모지가 존재하지 않아 예외가 발생한다.")
+        void createCategory_fail_emojiNotExist() {
+            // given
+            Long userId = 12L;
+            Long emojiId = 999L;
+            CategoryCreateUpdateRequestDto requestDto = new CategoryCreateUpdateRequestDto("Study", emojiId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            doThrow(new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST))
+                    .when(emojiValidator).checkIsExistEmoji(emojiId);
+
+            // when & then
+            assertThatThrownBy(() -> categoryService.createCategory(userId, requestDto))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-CATEGORY-001][TC-CREATE-004] 요청한 사용자가 존재하지 않아 예외가 발생한다.")
+        void createCategory_fail_userNotExist() {
+            // given
+            Long userId = 404L;
+            Long emojiId = 1L;
+            CategoryCreateUpdateRequestDto requestDto = new CategoryCreateUpdateRequestDto("Etc", emojiId);
+
+            doThrow(new CustomException(CategoryErrorStatus._CATEGORY_NOT_EXIST))
+                    .when(userValidator).checkIsExistUser(userId);
+
+            // when & then
+            assertThatThrownBy(() -> categoryService.createCategory(userId, requestDto))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+}

--- a/src/test/java/server/poptato/category/application/CategoryServiceTest.java
+++ b/src/test/java/server/poptato/category/application/CategoryServiceTest.java
@@ -216,7 +216,7 @@ public class CategoryServiceTest extends ServiceTestConfig {
 
                 // then
                 assertThat(responseDto.categories()).isEmpty();
-                assertThat(responseDto.totalPageCount()).isEqualTo(0);
+                assertThat(responseDto.totalPageCount()).isZero();
                 verifyNoInteractions(emojiRepository);
                 mocked.verifyNoInteractions();
             }

--- a/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
+++ b/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
@@ -51,8 +51,7 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
             Optional<Integer> maxOrder = jpaCategoryRepository.findMaxCategoryOrderByUserId(userId);
 
             // then
-            assertThat(maxOrder).isPresent();
-            assertThat(maxOrder).contains(9);
+            assertThat(maxOrder).isPresent().contains(9);
         }
 
         @Test

--- a/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
+++ b/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
@@ -1,0 +1,72 @@
+package server.poptato.category.infra;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import server.poptato.category.domain.entity.Category;
+import server.poptato.configuration.DatabaseTestConfig;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
+
+    @Autowired
+    private JpaCategoryRepository jpaCategoryRepository;
+
+    private void seed(Long userId, int order, String name) {
+        Category c = Category.builder()
+                .userId(userId)
+                .categoryOrder(order)
+                .emojiId(1L)
+                .name(name)
+                .build();
+        tem.persist(c);
+        tem.flush();
+        tem.clear();
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-CATEGORY-001] 기본(-1,0)과 사용자 카테고리에 대해 최대 categoryOrder를 조회한다")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class FindMaxCategoryOrder {
+
+        @Test
+        @DisplayName("[SCN-REP-CATEGORY-001][TC-MAX-ORDER-001] 사용자 카테고리와 기본 카테고리를을 합쳐 가장 큰 categoryOrder 값을 반환한다")
+        void returnsMaxOrderAcrossUserAndSystem() {
+            // given
+            Long userId = 100L;
+
+            seed(-1L, -1, "기본-전체");
+            seed(-1L, 0, "기본-중요");
+            seed(userId, 2, "me-2");
+            seed(userId, 9, "me-9");
+            seed(999L, 99, "other-99");
+
+            // when
+            Optional<Integer> maxOrder = jpaCategoryRepository.findMaxCategoryOrderByUserId(userId);
+
+            // then
+            assertThat(maxOrder).isPresent();
+            assertThat(maxOrder.get()).isEqualTo(9);
+        }
+
+        @Test
+        @DisplayName("[SCN-REPO-CATEGORY-001][TC-MAX-ORDER-002] 사용자 카테고리가 없으면 기본 카테고리 중 가장 큰 categoryOrder를 반환한다")
+        void returnsEmptyWhenNoUserAndNoDefaultCategories() {
+            // given
+            Long userId = 200L;
+            seed(-1L, -1, "기본-전체");
+            seed(-1L, 0, "기본-중요");
+
+            // when
+            Optional<Integer> maxOrder = jpaCategoryRepository.findMaxCategoryOrderByUserId(userId);
+
+            // then
+            assertThat(maxOrder).isPresent();
+            assertThat(maxOrder.get()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
+++ b/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
@@ -3,6 +3,8 @@ package server.poptato.category.infra;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import server.poptato.category.domain.entity.Category;
 import server.poptato.configuration.DatabaseTestConfig;
 
@@ -67,6 +69,58 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
             // then
             assertThat(maxOrder).isPresent();
             assertThat(maxOrder.get()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-CATEGORY-002] 기본(-1,0)과 사용자 카테고리를 categoryOrder 오름차순으로 페이지 조회한다")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class FindDefaultAndByUserIdOrderedPage {
+
+        @Test
+        @DisplayName("[SCN-REP-CATEGORY-002][TC-PAGE-001] 기본(-1,0)과 사용자 카테고리를 합쳐 categoryOrder 오름차순으로 반환한다")
+        void returnsOrderedAsc_includingDefaultAndUser_excludingOthers() {
+            // given
+            Long userId = 300L;
+            seed(-1L, -1, "기본-전체");
+            seed(-1L,  0, "기본-중요");
+            seed(userId, 1, "me-1");
+            seed(userId, 3, "me-3");
+            seed(userId, 2, "me-2");
+            seed(999L, 99, "other-99");
+
+            // when
+            Page<Category> page = jpaCategoryRepository
+                    .findDefaultAndByUserIdOrderByCategoryOrder(userId, PageRequest.of(0, 10));
+
+            // then
+            assertThat(page.getContent()).extracting(Category::getUserId)
+                    .allMatch(uid -> uid.equals(userId) || uid == -1L);
+            assertThat(page.getContent()).extracting(Category::getCategoryOrder)
+                    .containsExactly(-1, 0, 1, 2, 3);
+            assertThat(page.getTotalElements()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("[SCN-REP-CATEGORY-002][TC-PAGE-002] 조회 대상이 없으면 기본 카테고리(-1,0)만 반환한다")
+        void returnsEmptyPage_whenNoDefaultAndNoUser() {
+            // given
+            Long userId = 400L;
+            seed(-1L, -1, "기본-전체");
+            seed(-1L,  0, "기본-중요");
+
+
+            // when
+            Page<Category> page = jpaCategoryRepository
+                    .findDefaultAndByUserIdOrderByCategoryOrder(userId, PageRequest.of(0, 5));
+
+            // then
+            assertThat(page.getContent()).extracting(Category::getUserId)
+                    .allMatch(uid -> uid == -1L);
+            assertThat(page.getContent()).extracting(Category::getCategoryOrder)
+                    .containsExactly(-1, 0);
+            assertThat(page.getTotalElements()).isEqualTo(2);
+            assertThat(page.getTotalPages()).isEqualTo(1);
         }
     }
 }

--- a/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
+++ b/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
@@ -52,7 +52,7 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
 
             // then
             assertThat(maxOrder).isPresent();
-            assertThat(maxOrder.get()).isEqualTo(9);
+            assertThat(maxOrder).contains(9);
         }
 
         @Test
@@ -68,7 +68,7 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
 
             // then
             assertThat(maxOrder).isPresent();
-            assertThat(maxOrder.get()).isEqualTo(0);
+            assertThat(maxOrder.get()).isZero();
         }
     }
 

--- a/src/test/java/server/poptato/category/validator/CategoryValidatorTest.java
+++ b/src/test/java/server/poptato/category/validator/CategoryValidatorTest.java
@@ -99,4 +99,69 @@ class CategoryValidatorTest extends ServiceTestConfig {
             ).isInstanceOf(CustomException.class);
         }
     }
+
+    @Nested
+    @DisplayName("[SCN-VALID-CATEGORY-002] 특정 카테고리를 검증한다.")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class ValidateCategory {
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-002][TC-VALID-OK-001] 본인 소유 카테고리면 예외 없이 통과한다")
+        void ownCategory_noException() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 200L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category(userId)));
+
+            // expect
+            assertThatCode(() -> categoryValidator.validateCategory(userId, categoryId))
+                    .doesNotThrowAnyException();
+
+            // then
+            verify(categoryRepository).findById(categoryId);
+        }
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-002][TC-VALID-OK-002] 기본 카테고리(-1L)면 예외 없이 통과한다")
+        void defaultCategory_noException() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 201L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category(-1L)));
+
+            // expect
+            assertThatCode(() -> categoryValidator.validateCategory(userId, categoryId))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-002][TC-NOT-EXIST-001] 카테고리가 없으면 _CATEGORY_NOT_EXIST 예외를 던진다")
+        void notExist_throwsCategoryNotExist() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 999L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.empty());
+
+            // expect
+            assertThatThrownBy(() -> categoryValidator.validateCategory(userId, categoryId))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-002][TC-OWNER-MISMATCH-001] 소유자 불일치면 _CATEGORY_USER_NOT_MATCH 예외를 던진다")
+        void ownerMismatch_throwsUserNotMatch() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 202L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category(20L)));
+
+            // expect
+            assertThatThrownBy(() -> categoryValidator.validateCategory(userId, categoryId))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
 }

--- a/src/test/java/server/poptato/category/validator/CategoryValidatorTest.java
+++ b/src/test/java/server/poptato/category/validator/CategoryValidatorTest.java
@@ -1,0 +1,102 @@
+package server.poptato.category.validator;
+
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import server.poptato.category.domain.entity.Category;
+import server.poptato.category.domain.repository.CategoryRepository;
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.global.exception.CustomException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+class CategoryValidatorTest extends ServiceTestConfig {
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @InjectMocks
+    CategoryValidator categoryValidator;
+
+    private Category category(Long ownerId) {
+        return Category.builder()
+                .userId(ownerId)
+                .categoryOrder(0)
+                .emojiId(1L)
+                .name("dummy")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("[SCN-VALID-CATEGORY-001] 특정 카테고리를 검증하고, 검증에 성공하면 해당 카테고리를 반환한다.")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class ValidateAndReturnCategory {
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-001][TC-RETURN-OK-001] 본인 소유 카테고리면 Category를 정상적으로 반환한다")
+        void ownCategory_returnsCategory() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 100L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category(userId)));
+
+            // when
+            Category result = categoryValidator.validateAndReturnCategory(userId, categoryId);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(categoryRepository).findById(categoryId);
+        }
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-001][TC-RETURN-OK-002] 기본 카테고리(-1L)면 Category를 정상적으로 반환한다")
+        void defaultCategory_returnsCategory() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 101L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category(-1L)));
+
+            // when
+            Category result = categoryValidator.validateAndReturnCategory(userId, categoryId);
+
+            // then
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-001][TC-NOT-EXIST-001] 카테고리가 없으면 _CATEGORY_NOT_EXIST 예외를 던진다")
+        void notExist_throwsCategoryNotExist() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 999L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.empty());
+
+            // expect
+            assertThatThrownBy(() ->
+                    categoryValidator.validateAndReturnCategory(userId, categoryId)
+            ).isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("[SCN-VALID-CATEGORY-001][TC-OWNER-MISMATCH-001] 소유자 불일치면 _CATEGORY_USER_NOT_MATCH 예외를 던진다")
+        void ownerMismatch_throwsUserNotMatch() {
+            // given
+            Long userId = 10L;
+            Long categoryId = 102L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category(20L)));
+
+            // expect
+            assertThatThrownBy(() ->
+                    categoryValidator.validateAndReturnCategory(userId, categoryId)
+            ).isInstanceOf(CustomException.class);
+        }
+    }
+}

--- a/src/test/java/server/poptato/configuration/DatabaseTestConfig.java
+++ b/src/test/java/server/poptato/configuration/DatabaseTestConfig.java
@@ -20,7 +20,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public abstract class DatabaseTestConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DatabaseTestConfig.class);
-    private static final String MYSQL_IMAGE = "mysql:8.0.36";
+    private static final String MYSQL_IMAGE = "mysql:8.0.42";
 
     @Autowired
     protected TestEntityManager tem;

--- a/src/test/java/server/poptato/configuration/DatabaseTestConfig.java
+++ b/src/test/java/server/poptato/configuration/DatabaseTestConfig.java
@@ -1,10 +1,11 @@
 package server.poptato.configuration;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,8 +14,8 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@DataJpaTest
 @Testcontainers
+@TestMethodOrder(MethodOrderer.DisplayName.class)
 @ActiveProfiles("unittest")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class DatabaseTestConfig {
@@ -28,10 +29,9 @@ public abstract class DatabaseTestConfig {
 
     @Container
     @ServiceConnection
-    private static final MySQLContainer<?> MYSQL_CONTAINER =
+    public static final MySQLContainer<?> MYSQL_CONTAINER =
             new MySQLContainer<>(MYSQL_IMAGE)
                     .withCommand("--default-time-zone=+09:00")
                     .withLogConsumer(new Slf4jLogConsumer(log))
                     .withReuse(true);
-
 }

--- a/src/test/java/server/poptato/configuration/RedisTestConfig.java
+++ b/src/test/java/server/poptato/configuration/RedisTestConfig.java
@@ -17,7 +17,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public abstract class RedisTestConfig {
 
     private static final Logger log = LoggerFactory.getLogger(RedisTestConfig.class);
-    private static final String REDIS_IMAGE = "redis:7.0";
+    private static final String REDIS_IMAGE = "redis:alpine";
 
     @Container
     @ServiceConnection

--- a/src/test/java/server/poptato/configuration/ServiceTestConfig.java
+++ b/src/test/java/server/poptato/configuration/ServiceTestConfig.java
@@ -1,10 +1,13 @@
 package server.poptato.configuration;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.DisplayName.class)
 @ActiveProfiles("unittest")
 public abstract class ServiceTestConfig {
 }

--- a/src/test/java/server/poptato/emoji/infra/JpaEmojiRepositoryTest.java
+++ b/src/test/java/server/poptato/emoji/infra/JpaEmojiRepositoryTest.java
@@ -3,6 +3,7 @@ package server.poptato.emoji.infra;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +15,7 @@ import server.poptato.emoji.domain.value.GroupName;
 import java.util.List;
 import java.util.stream.IntStream;
 
+@DataJpaTest
 class JpaEmojiRepositoryTest extends DatabaseTestConfig {
 
     @Autowired

--- a/src/test/resources/application-unittest.yml
+++ b/src/test/resources/application-unittest.yml
@@ -8,6 +8,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+
   datasource: { }
 
 logging:


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 테스트코드 추가
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

테스트 시나리오별 테스트 케이스 정리, 테스트 코드 추가

### CATEGORY-SERVICE
#### [SCN-SVC-CATEGORY-001] 카테고리를 생성한다.
- [TC-CREATE-001] 카테고리를 정상적으로 생성한다
- [TC-CREATE-002] 기본 카테고리가 존재하지 않아 예외가 발생한다
- [TC-CREATE-003] 요청한 이모지가 존재하지 않아 예외가 발생한다
- [TC-CREATE-004] 요청한 사용자가 존재하지 않아 예외가 발생한다

#### [SCN-SVC-CATEGORY-002] 카테고리 목록을 조회한다.
- [TC-LIST-001] 정상 조회 시 이모지 URL을 확장자로 변환하여 DTO 목록과 totalPages를 반환한다
- [TC-LIST-002] 조회 결과가 비어 있으면 빈 목록과 totalPages 0을 반환하며 이모지 조회와 파일 확장자 변환을 호출하지 않는다
- [TC-LIST-003] 사용자가 존재하지 않으면 예외를 던지고 카테고리 조회와 이모지 조회 그리고 파일 확장자 변환을 수행하지 않는다
- [TC-LIST-004] N개 항목이 조회되면 파일 확장자 변환 함수가 각 항목마다 정확히 한 번씩 호출된다

#### [SCN-SVC-CATEGORY-003] 카테고리를 수정한다.
- [TC-UPDATE-001] 일단의 개인정보 처리방침을 반환한다
- [TC-UPDATE-002] 사용자가 존재하지 않으면 예외를 던지고 카테고리 조회와 저장을 수행하지 않는다
- [TC-UPDATE-003] 요청한 이모지가 존재하지 않으면 예외를 던지고 카테고리 조회와 저장을 수행하지 않는다
- [TC-UPDATE-004] 대상 카테고리가 유효하지 않으면 예외를 던지고 저장을 수행하지 않는다
- [TC-UPDATE-005] 검증과 저장 호출 순서를 사용자 검증 다음에 이모지 검증 그 다음에 카테고리 검증 마지막에 저장으로 보장한다

#### [SCN-SVC-CATEGORY-004] 카테고리를 삭제한다.
- [TC-DELETE-001] 정상 삭제 시 카테고리 삭제와 연관 Todo 삭제를 한 번씩 수행한다
- [TC-DELETE-002] 사용자가 존재하지 않으면 예외를 던지고 카테고리 검증과 삭제를 수행하지 않는다
- [TC-DELETE-003] 대상 카테고리가 유효하지 않으면 예외를 던지고 카테고리 삭제와 연관 Todo 삭제를 수행하지 않는다

#### [SCN-SVC-CATEGORY-005] 카테고리 순서를 재배치한다.
- [TC-REORDER-001] 정상적으로 순서를 변경하면 기존 categoryOrder의 오름차순 값을 요청 ID 순서대로 재할당하고 각 카테고리를 한 번씩 저장한다
- [TC-REORDER-002] 사용자가 존재하지 않으면 예외를 던지고 카테고리 조회와 검증 그리고 저장을 수행하지 않는다
- [TC-REORDER-003] 요청 목록에 기본 카테고리(−1, 0)가 포함되어 있으면 예외를 던지고 저장을 수행하지 않는다
- [TC-REORDER-004] 요청 목록에 존재하지 않는 카테고리 ID가 포함되어 있으면 예외를 던지고 저장을 수행하지 않는다
- [TC-REORDER-005] 카테고리 검증에서 소유자 불일치 등으로 실패하면 예외를 던지고 저장을 수행하지 않는다

### CATEGORY-REPOSITORY
#### [SCN-REP-CATEGORY-001] 기본(-1,0)과 사용자 카테고리에 대해 최대 categoryOrder를 조회한다.
- [TC-MAX-ORDER-001] 사용자 카테고리와 기본 카테고리를을 합쳐 가장 큰 categoryOrder 값을 반환한다
- [TC-MAX-ORDER-002]사용자 카테고리가 없으면 기본 카테고리 중 가장 큰 categoryOrder를 반환한다

#### [SCN-REP-CATEGORY-002] 기본(-1,0)과 사용자 카테고리를 categoryOrder 오름차순으로 페이지 조회한다.
- [TC-PAGE-001] 기본(-1,0)과 사용자 카테고리를 합쳐 categoryOrder 오름차순으로 반환한다
- [TC-PAGE-002] 조회 대상이 없으면 기본 카테고리(-1,0)만 반환한다

### CATEGORY-VALIDATOR
#### [SCN-VALID-CATEGORY-001] 특정 카테고리를 검증하고, 검증에 성공하면 해당 카테고리를 반환한다.
- [TC-RETURN-OK-001] 본인 소유 카테고리면 Category를 정상적으로 반환한다.
- [TC-RETURN-OK-002] 기본 카테고리(-1L)면 Category를 정상적으로 반환한다.
- [TC-NOT-EXIST-001] 카테고리가 없으면 _CATEGORY_NOT_EXIST 예외를 던진다.
- [TC-OWNER-MISMATCH-001] 소유자 불일치면 _CATEGORY_USER_NOT_MATCH 예외를 던진다.

#### [SCN-VALID-CATEGORY-002] 특정 카테고리를 검증한다.
- [TC-VALID-OK-001] 본인 소유 카테고리면 예외 없이 통과한다.
- [TC-VALID-OK-002] 기본 카테고리(-1L)면 예외 없이 통과한다.
- [TC-NOT-EXIST-001] 카테고리가 없으면 _CATEGORY_NOT_EXIST 예외를 던진다.
- [TC-OWNER-MISMATCH-001] 소유자 불일치면 _CATEGORY_USER_NOT_MATCH 예외를 던진다.

### Category 테스트 커버리지 결과
| 요소 | 클래스, % | 메서드, % | 줄, % | 브랜치, % |
| :--- | :--- | :--- | :--- | :--- |
| **category** | **91% (11/12)** | **84% (44/52)** | **89% (131/146)** | **95% (19/20)** |
| &nbsp;&nbsp;&nbsp;api | 100% (3/3) | 100% (8/8) | 100% (13/13) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;application | 100% (4/4) | 100% (19/19) | 100% (76/76) | 91% (11/12) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response | 100% (3/3) | 100% (5/5) | 100% (8/8) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CategoryService(추가) | 100% (1/1) | 100% (14/14) | 100% (68/68) | 91% (11/12) |
| &nbsp;&nbsp;&nbsp;domain | 66% (2/3) | 61% (8/13) | 61% (13/21) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;infra | 100% (0/0) | 100% (0/0) | 100% (0/0) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;status | 100% (1/1) | 62% (5/8) | 65% (13/20) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;validator | 100% (1/1) | 100% (4/4) | 100% (16/16) | 100% (8/8) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CategoryValidator(추가) | 100% (1/1) | 100% (4/4) | 100% (16/16) | 100% (8/8) |

- CategoryService 100% 라인 커버리지, 91% 브랜치 커버리지
- CategoryValidator 100% 라인 커버리지, 100% 브랜치 커버리지 달성
---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.


---