### PR TITLE
ILLDAN-183 [test]: Auth/jwt 서비스 단위 테스트 코드를 추가한다 

### DIFF
--- a/src/test/java/server/poptato/auth/application/JwtServiceRedisTest.java
+++ b/src/test/java/server/poptato/auth/application/JwtServiceRedisTest.java
@@ -77,7 +77,7 @@ class JwtServiceRedisTest extends ServiceTestConfig {
             when(valueOps.get("123")).thenReturn("refresh-token");
 
             // when & then
-            assertThatCode(() -> jwtService.compareRefreshToken("123", "r-token"))
+            assertThatCode(() -> jwtService.compareRefreshToken("123", "refresh-token"))
                     .doesNotThrowAnyException();
         }
 

--- a/src/test/java/server/poptato/auth/application/JwtServiceRedisTest.java
+++ b/src/test/java/server/poptato/auth/application/JwtServiceRedisTest.java
@@ -1,0 +1,149 @@
+package server.poptato.auth.application;
+
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.poptato.auth.application.service.JwtService;
+import server.poptato.auth.status.AuthErrorStatus;
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.global.dto.TokenPair;
+import server.poptato.global.exception.CustomException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class JwtServiceRedisTest extends ServiceTestConfig {
+
+    @Mock
+    StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    ValueOperations<String, String> valueOps;
+
+    @InjectMocks
+    private JwtService jwtService;
+
+    private static final String RAW_SECRET = "this-is-a-test-secret-at-least-32-bytes";
+    private static final String BASE64_SECRET =
+            Base64.getEncoder().encodeToString(RAW_SECRET.getBytes(StandardCharsets.UTF_8));
+
+    @BeforeEach
+    void setUp() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+        ReflectionTestUtils.setField(jwtService, "jwtSecret", BASE64_SECRET);
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    @DisplayName("[SCN-SVC-AUTH-JWT-004] 토큰 페어를 발급받고 Redis에 저장/비교/장애를 처리할 수 있다.")
+    class TokenPairRedis {
+
+        @Test
+        @DisplayName("[TC-REDIS-001] 토큰 페어 생성 과정에서 Redis에 Refresh 토큰이 userId 기준으로 14일간 보관된다")
+        void generateTokenPair_savesRefreshToRedis() {
+            // given
+            String userId = "123";
+
+            // when
+            TokenPair pair = jwtService.generateTokenPair(userId);
+
+            // then
+            ArgumentCaptor<String> refreshCaptor = ArgumentCaptor.forClass(String.class);
+            verify(valueOps).set(
+                    eq(userId),
+                    refreshCaptor.capture(),
+                    eq((long) JwtService.REFRESH_TOKEN_EXPIRATION_DAYS),
+                    eq(TimeUnit.DAYS)
+            );
+            assertThat(refreshCaptor.getValue()).isNotBlank();
+            assertThat(pair.refreshToken()).isNotBlank();
+            assertThat(pair.accessToken()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("[TC-REDIS-002] Redis 저장값과 입력 Refresh 토큰이 같으면 비교 검증이 통과한다")
+        void compareRefreshToken_match() {
+            // given
+            when(valueOps.get("123")).thenReturn("refresh-token");
+
+            // when & then
+            assertThatCode(() -> jwtService.compareRefreshToken("123", "r-token"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("[TC-REDIS-003] Refresh 토큰을 삭제하면 Redis에서 해당 키가 삭제된다")
+        void deleteRefreshToken_deletesKey() {
+            // given
+            reset(stringRedisTemplate);
+
+            // when
+            jwtService.deleteRefreshToken("123");
+
+            // then
+            verify(stringRedisTemplate).delete("123");
+        }
+
+        @Test
+        @DisplayName("[TC-REDIS-EXCEPTION-001] Redis에 저장된 Refresh 토큰이 없으면 _EXPIRED_OR_NOT_FOUND_REFRESH_TOKEN_IN_REDIS 예외가 발생한다")
+        void compareRefreshToken_notFound() {
+            // given
+            when(valueOps.get("123")).thenReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> jwtService.compareRefreshToken("123", "x"))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> assertThat(((CustomException) ex).getHttpStatus())
+                            .isEqualTo(AuthErrorStatus._EXPIRED_OR_NOT_FOUND_REFRESH_TOKEN_IN_REDIS.getHttpStatus()));
+        }
+
+        @Test
+        @DisplayName("[TC-REDIS-EXCEPTION-002] Redis 저장값과 입력 Refresh 토큰이 다르면 _DIFFERENT_REFRESH_TOKEN 예외가 발생한다")
+        void compareRefreshToken_different() {
+            // given
+            when(valueOps.get("123")).thenReturn("stored");
+
+            // when & then
+            assertThatThrownBy(() -> jwtService.compareRefreshToken("123", "input"))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> assertThat(((CustomException) ex).getHttpStatus())
+                            .isEqualTo(AuthErrorStatus._DIFFERENT_REFRESH_TOKEN.getHttpStatus()));
+        }
+
+        @Test
+        @DisplayName("[TC-REDIS-EXCEPTION-003] RedisConnectionFailureException이 발생하면 _REDIS_UNAVAILABLE 예외가 발생한다")
+        void compareRefreshToken_redisDown_connectionFailure() {
+            // given
+            when(valueOps.get("123")).thenThrow(new RedisConnectionFailureException("down"));
+
+            // when & then
+            assertThatThrownBy(() -> jwtService.compareRefreshToken("123", "r"))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> assertThat(((CustomException) ex).getHttpStatus())
+                            .isEqualTo(AuthErrorStatus._REDIS_UNAVAILABLE.getHttpStatus()));
+        }
+
+        @Test
+        @DisplayName("[TC-REDIS-EXCEPTION-004] RedisCommandTimeoutException이 발생하면 _REDIS_UNAVAILABLE 예외가 발생한다")
+        void compareRefreshToken_redisDown_timeout() {
+            // given
+            when(valueOps.get("123")).thenThrow(new io.lettuce.core.RedisCommandTimeoutException("timeout"));
+
+            // when & then
+            assertThatThrownBy(() -> jwtService.compareRefreshToken("123", "r"))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> assertThat(((CustomException) ex).getHttpStatus())
+                            .isEqualTo(AuthErrorStatus._REDIS_UNAVAILABLE.getHttpStatus()));
+        }
+    }
+}

--- a/src/test/java/server/poptato/auth/application/JwtServiceTokenTest.java
+++ b/src/test/java/server/poptato/auth/application/JwtServiceTokenTest.java
@@ -1,0 +1,123 @@
+package server.poptato.auth.application;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.poptato.auth.application.service.JwtService;
+import server.poptato.auth.status.AuthErrorStatus;
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.global.exception.CustomException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.*;
+
+class JwtServiceTokenTest extends ServiceTestConfig {
+
+    @InjectMocks
+    private JwtService jwtService;
+
+    private static final String RAW_SECRET = "this-is-a-test-secret-at-least-32-bytes";
+    private static final String OTHER_RAW_SECRET = "another-different-test-secret-32-bytes";
+    private static final String BASE64_SECRET = Base64.getEncoder().encodeToString(RAW_SECRET.getBytes(StandardCharsets.UTF_8));
+    private static final String OTHER_BASE64_SECRET = Base64.getEncoder().encodeToString(OTHER_RAW_SECRET.getBytes(StandardCharsets.UTF_8));
+
+    private static String bearer(String token) {
+        return "Bearer " + token;
+    }
+
+    private static String validAccess(String userId, String base64Secret) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime()
+                + JwtService.ACCESS_TOKEN_EXPIRATION_MINUTE * JwtService.MINUTE_IN_MILLISECONDS);
+        Claims c = Jwts.claims()
+                .setSubject("ACCESS_TOKEN")
+                .setIssuedAt(now)
+                .setExpiration(exp);
+        c.put("USER_ID", userId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(c)
+                .signWith(Keys.hmacShaKeyFor(base64Secret.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    private static String expiredToken(String subject, String userId, String base64Secret) {
+        long now = System.currentTimeMillis();
+        Date past = new Date(now - 1_000L);
+        Claims c = Jwts.claims()
+                .setSubject(subject)
+                .setIssuedAt(new Date(past.getTime() - 1_000L))
+                .setExpiration(past);
+        c.put("USER_ID", userId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(c)
+                .signWith(Keys.hmacShaKeyFor(base64Secret.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    private static String forgedToken(String subject, String userId, String otherBase64Secret) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime()
+                + JwtService.ACCESS_TOKEN_EXPIRATION_MINUTE * JwtService.MINUTE_IN_MILLISECONDS);
+        Claims c = Jwts.claims()
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(exp);
+        c.put("USER_ID", userId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(c)
+                .signWith(Keys.hmacShaKeyFor(otherBase64Secret.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jwtService, "jwtSecret", BASE64_SECRET);
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    @DisplayName("[SCN-SVC-AUTH-JWT-001] 토큰을 생성하고 검증,파싱할 수 있다.")
+    class CreateToken {
+
+        @Test
+        @DisplayName("[TC-CREATE-TOKEN-001] Access 토큰 생성/검증 통과 후 userId를 정상적으로 추출한다")
+        void accessToken_create_verify_parse_userId() {
+            // given
+            String userId = "123";
+
+            // when
+            String accessToken = jwtService.createAccessToken(userId);
+
+            // then
+            assertThatCode(() -> jwtService.verifyAccessToken(accessToken)).doesNotThrowAnyException();
+            assertThat(jwtService.getUserIdInToken(accessToken)).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("[TC-CREATE-TOKEN-002] Refresh 토큰 생성/검증 통과 후 userId를 정상적으로 추출한다")
+        void refreshToken_create_verify_parse_userId() {
+            // given
+            String userId = "123";
+
+            // when
+            String refreshToken = jwtService.createRefreshToken(userId);
+
+            // then
+            assertThatCode(() -> jwtService.verifyRefreshToken(refreshToken)).doesNotThrowAnyException();
+            assertThat(jwtService.getUserIdInToken(refreshToken)).isEqualTo(userId);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 테스트코드 추가
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 📝 개요
JwtService의 주요 기능에 대한 통합 단위 테스트를 시나리오 단위로 구성하여 추가했습니다.
Access/Refresh 토큰 생성, 검증, 헤더 파싱, Redis 연동 로직 등 서비스 전반의 핵심 로직을 검증합니다.
각 시나리오는 실제 동작 플로우를 기준으로 설계되었으며, 정상 케이스와 예외 케이스를 모두 포함합니다.

### 🔍 주요 변경 사항
#### 1️⃣ [SCN-SVC-AUTH-JWT-001] 토큰 생성 시나리오

Access, Refresh 토큰을 생성하고 검증 후 USER_ID를 정상적으로 추출하는지 확인

#### 테스트 케이스
| ID | 설명 |
|----|------|
| TC-CREATE-TOKEN-001 | Access 토큰 생성/검증 통과 후 USER_ID 정상 추출 |
| TC-CREATE-TOKEN-002 | Refresh 토큰 생성/검증 통과 후 USER_ID 정상 추출 |

#### 2️⃣ [SCN-SVC-AUTH-JWT-002] 토큰 검증 및 예외 처리 시나리오

만료 또는 위조된 토큰 검증 시 적절한 예외가 발생하는지 검증

#### 테스트 케이스
| ID | 설명 |
|----|------|
| TC-VERIFY-ERRORS-001 | 만료된 Access 토큰 → _EXPIRED_ACCESS_TOKEN |
| TC-VERIFY-ERRORS-002 | 만료된 Refresh 토큰 → _EXPIRED_REFRESH_TOKEN |
| TC-VERIFY-ERRORS-003 | 서명이 불일치한 Access 토큰 → _INVALID_ACCESS_TOKEN |
| TC-VERIFY-ERRORS-004 | 서명이 불일치한 Refresh 토큰 → _INVALID_REFRESH_TOKEN |

#### 3️⃣ [SCN-SVC-AUTH-JWT-003] Authorization 헤더 파싱 시나리오

Authorization 헤더에서 토큰을 추출하여 USER_ID를 반환하거나, 비정상 입력에 대해 예외 발생

#### 테스트 케이스
| ID | 설명 |
|----|------|
| TC-AUTH-HEADER-001 | 정상 헤더에서 사용자 ID 반환 |
| TC-AUTH-HEADER-EXCEPTION-001 | 헤더 없음 / 접두어 불일치 → _NOT_EXIST_ACCESS_TOKEN |
| TC-AUTH-HEADER-EXCEPTION-002 | 만료된 토큰 포함 시 _EXPIRED_ACCESS_TOKEN |
| TC-AUTH-HEADER-EXCEPTION-003 | 위조된 토큰 포함 시 _INVALID_ACCESS_TOKEN |

#### 4️⃣ [SCN-SVC-AUTH-JWT-004] Redis 기반 토큰 페어 관리 시나리오

토큰 페어 발급 시 Redis 저장, 비교, 삭제, 장애 상황까지 포함

#### 테스트 케이스
| ID | 설명 |
|----|------|
| TC-REDIS-001 | Refresh 토큰이 userId 기준으로 14일간 Redis에 저장됨 |
| TC-REDIS-002 | Redis 저장값과 입력 Refresh 토큰이 같을 경우 정상 통과 |
| TC-REDIS-003 | Refresh 토큰 삭제 시 Redis에서 키 삭제 확인 |
| TC-REDIS-EXCEPTION-001 | Redis에 저장값 없음 → _EXPIRED_OR_NOT_FOUND_REFRESH_TOKEN_IN_REDIS |
| TC-REDIS-EXCEPTION-002 | Redis 저장값과 입력 Refresh 토큰 불일치 → _DIFFERENT_REFRESH_TOKEN |
| TC-REDIS-EXCEPTION-003 | RedisConnectionFailureException 발생 시 _REDIS_UNAVAILABLE |
| TC-REDIS-EXCEPTION-004 | RedisCommandTimeoutException 발생 시 _REDIS_UNAVAILABLE |

#### 🧩 Auth/jwt 서비스 단위테스트 결과
| 요소 | 클래스, % | 메서드, % | 줄, % | 브랜치, % |
| :--- | :--- | :--- | :--- | :--- |
| **auth** | **100% (8/8)** | **91% (42/46)** | **90% (157/173)** | **85% (24/28)** |
| &nbsp;&nbsp;&nbsp;api | 100% (4/4) | 100% (7/7) | 100% (11/11) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;application | 100% (3/3) | 96% (30/31) | 93% (121/130) | 85% (24/28) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;response | 100% (1/1) | 100% (2/2) | 100% (2/2) | 100% (0/0) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;service | 100% (2/2) | 96% (28/29) | 92% (119/128) | 85% (24/28) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AuthService | 100% (1/1) | 100% (12/12) | 93% (55/59) | 80% (16/20) |
| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;JwtService(추가) | 100% (1/1) | 94% (16/17) | 92% (64/69) | 100% (8/8) |

- JwtService 라인 커버리지 92%, 브랜치 커버리지 100% 달성
---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.


---