### PR TITLE
ILLDAN-199 [feat]: 앱 업데이트 기능을 구현한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ out/
 
 .gitignore.swp
 /htmlReport/
+
+### Claude ###
+.claude
+CLAUDE.md

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ def serverUrl = "https://prev-illdan.store"
 
 openapi3 {
     server = serverUrl
-    title = "Legacy Illdan API Documentation"
+    title = "Illdan API Documentation"
     description = "Spring REST Docs with Swagger UI."
     version = "1.0.0"
     outputFileNamePrefix = 'open-api-3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/server/poptato/app/api/AppController.java
+++ b/src/main/java/server/poptato/app/api/AppController.java
@@ -1,0 +1,91 @@
+package server.poptato.app.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import server.poptato.app.api.request.SkipRequestDto;
+import server.poptato.app.application.AppService;
+import server.poptato.app.application.response.DownloadResponseDto;
+import server.poptato.app.application.response.VersionCheckResponseDto;
+import server.poptato.app.domain.value.Platform;
+import server.poptato.auth.application.service.JwtService;
+import server.poptato.global.response.ApiResponse;
+import server.poptato.global.response.status.SuccessStatus;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+public class AppController {
+
+    private final AppService appService;
+    private final JwtService jwtService;
+
+    /**
+     * 버전 체크 API.
+     *
+     * 현재 앱 버전과 플랫폼 정보를 받아 업데이트 필요 여부를 확인합니다.
+     *
+     * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
+     * @param currentVersion 현재 앱 버전 (e.g., "1.0.0")
+     * @param platform 플랫폼 (MACOS | WINDOWS)
+     * @return 업데이트 정보를 포함한 응답
+     */
+    @GetMapping("/version")
+    public ResponseEntity<ApiResponse<VersionCheckResponseDto>> checkVersion(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam String currentVersion,
+            @RequestParam Platform platform
+    ) {
+        Long userId = jwtService.extractUserIdFromToken(authorizationHeader);
+        VersionCheckResponseDto response = appService.checkVersion(userId, currentVersion, platform);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    /**
+     * 다운로드 URL 조회 API.
+     *
+     * 플랫폼에 해당하는 활성화된 릴리즈의 S3 Presigned URL을 반환합니다.
+     *
+     * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
+     * @param platform 플랫폼 (MACOS | WINDOWS)
+     * @param currentVersion 현재 앱 버전 (로깅용)
+     * @return 다운로드 정보를 포함한 응답
+     */
+    @GetMapping("/download")
+    public ResponseEntity<ApiResponse<DownloadResponseDto>> getDownloadUrl(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam Platform platform,
+            @RequestParam(required = false, defaultValue = "unknown") String currentVersion
+    ) {
+        Long userId = jwtService.extractUserIdFromToken(authorizationHeader);
+        DownloadResponseDto response = appService.getDownloadUrl(userId, platform, currentVersion);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    /**
+     * 업데이트 스킵 API.
+     *
+     * 사용자가 "다음에 설치" 선택 시 로그를 기록합니다.
+     *
+     * @param authorizationHeader 요청 헤더의 Authorization (Bearer 토큰)
+     * @param request 스킵 요청 데이터 (currentVersion, targetVersion, platform)
+     * @return 성공 응답
+     */
+    @PostMapping("/skip")
+    public ResponseEntity<ApiResponse<SuccessStatus>> skipUpdate(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Validated @RequestBody SkipRequestDto request
+    ) {
+        Long userId = jwtService.extractUserIdFromToken(authorizationHeader);
+        appService.skipUpdate(userId, request);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+}

--- a/src/main/java/server/poptato/app/api/request/SkipRequestDto.java
+++ b/src/main/java/server/poptato/app/api/request/SkipRequestDto.java
@@ -1,0 +1,17 @@
+package server.poptato.app.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import server.poptato.app.domain.value.Platform;
+
+public record SkipRequestDto(
+        @NotBlank(message = "currentVersion은 필수입니다.")
+        String currentVersion,
+
+        @NotBlank(message = "targetVersion은 필수입니다.")
+        String targetVersion,
+
+        @NotNull(message = "platform은 필수입니다.")
+        Platform platform
+) {
+}

--- a/src/main/java/server/poptato/app/application/AppService.java
+++ b/src/main/java/server/poptato/app/application/AppService.java
@@ -33,9 +33,9 @@ public class AppService {
                 .orElse(null);
 
         boolean updateAvailable = activeRelease != null && !activeRelease.getVersion().equals(currentVersion);
-
-        publishUpdateLogEvent(userId, UpdateEventType.VERSION_CHECK, currentVersion,
-                updateAvailable ? activeRelease.getVersion() : null, platform, updateAvailable);
+		
+		eventPublisher.publishEvent(AppUpdateLogEvent.of(userId, UpdateEventType.VERSION_CHECK, currentVersion,
+                updateAvailable ? activeRelease.getVersion() : null, platform, updateAvailable));
 
         if (!updateAvailable) {
             return VersionCheckResponseDto.noUpdate(currentVersion);
@@ -58,9 +58,9 @@ public class AppService {
         } catch (Exception e) {
             throw new CustomException(AppErrorStatus._PRESIGNED_URL_GENERATION_FAILED);
         }
-
-        publishUpdateLogEvent(userId, UpdateEventType.DOWNLOADED, currentVersion,
-                activeRelease.getVersion(), platform, true);
+		
+		eventPublisher.publishEvent(AppUpdateLogEvent.of(userId, UpdateEventType.DOWNLOADED, currentVersion,
+                activeRelease.getVersion(), platform, true));
 
         return DownloadResponseDto.of(activeRelease, presignedUrl);
     }
@@ -69,16 +69,7 @@ public class AppService {
      * 사용자가 업데이트를 스킵했을 때 로그를 기록한다.
      */
     public void skipUpdate(Long userId, SkipRequestDto request) {
-        publishUpdateLogEvent(userId, UpdateEventType.UPDATE_SKIPPED, request.currentVersion(),
-                request.targetVersion(), request.platform(), true);
-    }
-
-    /**
-     * 업데이트 로그 이벤트를 비동기로 발행한다.
-     */
-    private void publishUpdateLogEvent(Long userId, UpdateEventType eventType, String currentVersion,
-                                       String targetVersion, Platform platform, Boolean updateAvailable) {
-        eventPublisher.publishEvent(AppUpdateLogEvent.of(userId, eventType, currentVersion,
-                targetVersion, platform, updateAvailable));
+		eventPublisher.publishEvent(AppUpdateLogEvent.of(userId, UpdateEventType.UPDATE_SKIPPED, request.currentVersion(),
+                request.targetVersion(), request.platform(), true));
     }
 }

--- a/src/main/java/server/poptato/app/application/AppService.java
+++ b/src/main/java/server/poptato/app/application/AppService.java
@@ -1,0 +1,89 @@
+package server.poptato.app.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import server.poptato.app.api.request.SkipRequestDto;
+import server.poptato.app.application.response.DownloadResponseDto;
+import server.poptato.app.application.response.VersionCheckResponseDto;
+import server.poptato.app.domain.entity.AppRelease;
+import server.poptato.app.domain.entity.AppUpdateLog;
+import server.poptato.app.domain.repository.AppReleaseRepository;
+import server.poptato.app.domain.repository.AppUpdateLogRepository;
+import server.poptato.app.domain.value.Platform;
+import server.poptato.app.domain.value.UpdateEventType;
+import server.poptato.app.status.AppErrorStatus;
+import server.poptato.global.exception.CustomException;
+import server.poptato.infra.s3.service.S3Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppService {
+
+    private final AppReleaseRepository appReleaseRepository;
+    private final AppUpdateLogRepository appUpdateLogRepository;
+    private final S3Service s3Service;
+
+    /**
+     * 앱의 버전을 체크하고 업데이트 필요 여부를 반환한다.
+     * 업데이트 존재 여부와 관계없이 모든 VERSION_CHECK 호출을 로깅한다.
+     */
+    public VersionCheckResponseDto checkVersion(Long userId, String currentVersion, Platform platform) {
+        AppRelease activeRelease = appReleaseRepository.findByPlatformAndIsActiveTrue(platform)
+                .orElse(null);
+
+        boolean updateAvailable = activeRelease != null && !activeRelease.getVersion().equals(currentVersion);
+
+        saveUpdateLog(userId, UpdateEventType.VERSION_CHECK, currentVersion,
+                updateAvailable ? activeRelease.getVersion() : null, platform, updateAvailable);
+
+        if (!updateAvailable) {
+            return VersionCheckResponseDto.noUpdate(currentVersion);
+        }
+
+        return VersionCheckResponseDto.hasUpdate(currentVersion, activeRelease);
+    }
+
+    /**
+     * 다운로드 URL(S3 Presigned URL)을 생성하여 반환한다.
+     * S3 호출 성공 후에만 DOWNLOADED 로그를 저장한다.
+     */
+    public DownloadResponseDto getDownloadUrl(Long userId, Platform platform, String currentVersion) {
+        AppRelease activeRelease = appReleaseRepository.findByPlatformAndIsActiveTrue(platform)
+                .orElseThrow(() -> new CustomException(AppErrorStatus._RELEASE_NOT_FOUND));
+
+        String presignedUrl;
+        try {
+            presignedUrl = s3Service.generatePresignedUrl(activeRelease.getFilePath());
+        } catch (Exception e) {
+            throw new CustomException(AppErrorStatus._PRESIGNED_URL_GENERATION_FAILED);
+        }
+
+        saveUpdateLog(userId, UpdateEventType.DOWNLOADED, currentVersion,
+                activeRelease.getVersion(), platform, true);
+
+        return DownloadResponseDto.of(activeRelease, presignedUrl);
+    }
+
+    /**
+     * 사용자가 업데이트를 스킵했을 때 로그를 기록한다.
+     */
+    public void skipUpdate(Long userId, SkipRequestDto request) {
+        saveUpdateLog(userId, UpdateEventType.UPDATE_SKIPPED, request.currentVersion(),
+                request.targetVersion(), request.platform(), true);
+    }
+
+    private void saveUpdateLog(Long userId, UpdateEventType eventType, String currentVersion,
+                               String targetVersion, Platform platform, Boolean updateAvailable) {
+        AppUpdateLog log = AppUpdateLog.builder()
+                .userId(userId)
+                .eventType(eventType)
+                .currentVersion(currentVersion)
+                .targetVersion(targetVersion)
+                .platform(platform)
+                .updateAvailable(updateAvailable)
+                .build();
+
+        appUpdateLogRepository.save(log);
+    }
+}

--- a/src/main/java/server/poptato/app/application/event/AppUpdateLogEvent.java
+++ b/src/main/java/server/poptato/app/application/event/AppUpdateLogEvent.java
@@ -1,0 +1,17 @@
+package server.poptato.app.application.event;
+
+import server.poptato.app.domain.value.Platform;
+import server.poptato.app.domain.value.UpdateEventType;
+
+public record AppUpdateLogEvent(
+        Long userId,
+        UpdateEventType eventType,
+        String currentVersion,
+        String targetVersion,
+        Platform platform,
+        Boolean updateAvailable
+) {
+    public static AppUpdateLogEvent of(Long userId, UpdateEventType eventType, String currentVersion, String targetVersion, Platform platform, Boolean updateAvailable) {
+        return new AppUpdateLogEvent(userId, eventType, currentVersion, targetVersion, platform, updateAvailable);
+    }
+}

--- a/src/main/java/server/poptato/app/application/listener/AppEventListener.java
+++ b/src/main/java/server/poptato/app/application/listener/AppEventListener.java
@@ -1,0 +1,41 @@
+package server.poptato.app.application.listener;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import server.poptato.app.application.event.AppUpdateLogEvent;
+import server.poptato.app.domain.entity.AppUpdateLog;
+import server.poptato.app.domain.repository.AppUpdateLogRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppEventListener {
+
+    private final AppUpdateLogRepository appUpdateLogRepository;
+
+    /**
+     * 앱 업데이트 로그를 비동기로 저장한다.
+     */
+    @Async
+    @EventListener
+    public void handleAppUpdateLog(AppUpdateLogEvent event) {
+        try {
+            AppUpdateLog updateLog = AppUpdateLog.builder()
+                    .userId(event.userId())
+                    .eventType(event.eventType())
+                    .currentVersion(event.currentVersion())
+                    .targetVersion(event.targetVersion())
+                    .platform(event.platform())
+                    .updateAvailable(event.updateAvailable())
+                    .build();
+
+            appUpdateLogRepository.save(updateLog);
+        } catch (Exception e) {
+            log.error("앱 업데이트 로그 저장 실패: userId={}, eventType={}", event.userId(), event.eventType(), e);
+        }
+    }
+}

--- a/src/main/java/server/poptato/app/application/response/DownloadResponseDto.java
+++ b/src/main/java/server/poptato/app/application/response/DownloadResponseDto.java
@@ -1,0 +1,21 @@
+package server.poptato.app.application.response;
+
+import server.poptato.app.domain.entity.AppRelease;
+
+public record DownloadResponseDto(
+        String version,
+        String platform,
+        String downloadUrl,
+        String sha512,
+        Long size
+) {
+    public static DownloadResponseDto of(AppRelease release, String presignedUrl) {
+        return new DownloadResponseDto(
+                release.getVersion(),
+                release.getPlatform().name(),
+                presignedUrl,
+                release.getSha512(),
+                release.getFileSize()
+        );
+    }
+}

--- a/src/main/java/server/poptato/app/application/response/VersionCheckResponseDto.java
+++ b/src/main/java/server/poptato/app/application/response/VersionCheckResponseDto.java
@@ -1,0 +1,36 @@
+package server.poptato.app.application.response;
+
+import java.time.LocalDateTime;
+
+import server.poptato.app.domain.entity.AppRelease;
+
+public record VersionCheckResponseDto(
+        boolean updateAvailable,
+        String currentVersion,
+        String latestVersion,
+        LocalDateTime releaseDate,
+        String releaseNote,
+        Boolean isMandatory
+) {
+    public static VersionCheckResponseDto noUpdate(String currentVersion) {
+        return new VersionCheckResponseDto(
+                false,
+                currentVersion,
+                currentVersion,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static VersionCheckResponseDto hasUpdate(String currentVersion, AppRelease release) {
+        return new VersionCheckResponseDto(
+                true,
+                currentVersion,
+                release.getVersion(),
+                release.getCreateDate(),
+                release.getReleaseNotes(),
+                release.getIsMandatory()
+        );
+    }
+}

--- a/src/main/java/server/poptato/app/domain/entity/AppRelease.java
+++ b/src/main/java/server/poptato/app/domain/entity/AppRelease.java
@@ -1,0 +1,73 @@
+package server.poptato.app.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.poptato.app.domain.value.Platform;
+import server.poptato.global.dao.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "app_release")
+public class AppRelease extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
+    private Platform platform;
+
+    @Column(name = "file_path", nullable = false, length = 500)
+    private String filePath;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(nullable = false, length = 128)
+    private String sha512;
+
+    @Column(name = "release_notes", columnDefinition = "TEXT")
+    private String releaseNotes;
+
+    @Column(name = "is_mandatory", nullable = false)
+    private Boolean isMandatory;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Builder
+    public AppRelease(String version, Platform platform, String filePath, Long fileSize,
+                      String sha512, String releaseNotes, Boolean isMandatory, Boolean isActive) {
+        this.version = version;
+        this.platform = platform;
+        this.filePath = filePath;
+        this.fileSize = fileSize;
+        this.sha512 = sha512;
+        this.releaseNotes = releaseNotes;
+        this.isMandatory = isMandatory;
+        this.isActive = isActive;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+}

--- a/src/main/java/server/poptato/app/domain/entity/AppUpdateLog.java
+++ b/src/main/java/server/poptato/app/domain/entity/AppUpdateLog.java
@@ -1,0 +1,59 @@
+package server.poptato.app.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.poptato.app.domain.value.Platform;
+import server.poptato.app.domain.value.UpdateEventType;
+import server.poptato.global.dao.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "app_update_log")
+public class AppUpdateLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, columnDefinition = "VARCHAR(30)")
+    private UpdateEventType eventType;
+
+    @Column(name = "current_version", nullable = false, length = 20)
+    private String currentVersion;
+
+    @Column(name = "target_version", length = 20)
+    private String targetVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
+    private Platform platform;
+
+    @Column(name = "update_available", nullable = false)
+    private Boolean updateAvailable;
+
+    @Builder
+    public AppUpdateLog(Long userId, UpdateEventType eventType, String currentVersion,
+                        String targetVersion, Platform platform, Boolean updateAvailable) {
+        this.userId = userId;
+        this.eventType = eventType;
+        this.currentVersion = currentVersion;
+        this.targetVersion = targetVersion;
+        this.platform = platform;
+        this.updateAvailable = updateAvailable;
+    }
+}

--- a/src/main/java/server/poptato/app/domain/repository/AppReleaseRepository.java
+++ b/src/main/java/server/poptato/app/domain/repository/AppReleaseRepository.java
@@ -1,0 +1,13 @@
+package server.poptato.app.domain.repository;
+
+import java.util.Optional;
+
+import server.poptato.app.domain.entity.AppRelease;
+import server.poptato.app.domain.value.Platform;
+
+public interface AppReleaseRepository {
+
+    Optional<AppRelease> findByPlatformAndIsActiveTrue(Platform platform);
+
+    AppRelease save(AppRelease appRelease);
+}

--- a/src/main/java/server/poptato/app/domain/repository/AppUpdateLogRepository.java
+++ b/src/main/java/server/poptato/app/domain/repository/AppUpdateLogRepository.java
@@ -1,0 +1,8 @@
+package server.poptato.app.domain.repository;
+
+import server.poptato.app.domain.entity.AppUpdateLog;
+
+public interface AppUpdateLogRepository {
+
+    AppUpdateLog save(AppUpdateLog appUpdateLog);
+}

--- a/src/main/java/server/poptato/app/domain/value/Platform.java
+++ b/src/main/java/server/poptato/app/domain/value/Platform.java
@@ -1,0 +1,6 @@
+package server.poptato.app.domain.value;
+
+public enum Platform {
+    MACOS,
+    WINDOWS
+}

--- a/src/main/java/server/poptato/app/domain/value/UpdateEventType.java
+++ b/src/main/java/server/poptato/app/domain/value/UpdateEventType.java
@@ -1,14 +1,7 @@
 package server.poptato.app.domain.value;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum UpdateEventType {
-    VERSION_CHECK("VERSION_CHECK"),
-    DOWNLOADED("DOWNLOADED"),
-    UPDATE_SKIPPED("UPDATE_SKIPPED");
-
-    private final String value;
+    VERSION_CHECK,
+    DOWNLOADED,
+    UPDATE_SKIPPED
 }

--- a/src/main/java/server/poptato/app/domain/value/UpdateEventType.java
+++ b/src/main/java/server/poptato/app/domain/value/UpdateEventType.java
@@ -1,0 +1,14 @@
+package server.poptato.app.domain.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UpdateEventType {
+    VERSION_CHECK("VERSION_CHECK"),
+    DOWNLOADED("DOWNLOADED"),
+    UPDATE_SKIPPED("UPDATE_SKIPPED");
+
+    private final String value;
+}

--- a/src/main/java/server/poptato/app/infra/JpaAppReleaseRepository.java
+++ b/src/main/java/server/poptato/app/infra/JpaAppReleaseRepository.java
@@ -1,0 +1,9 @@
+package server.poptato.app.infra;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import server.poptato.app.domain.entity.AppRelease;
+import server.poptato.app.domain.repository.AppReleaseRepository;
+
+public interface JpaAppReleaseRepository extends AppReleaseRepository, JpaRepository<AppRelease, Long> {
+}

--- a/src/main/java/server/poptato/app/infra/JpaAppUpdateLogRepository.java
+++ b/src/main/java/server/poptato/app/infra/JpaAppUpdateLogRepository.java
@@ -1,0 +1,9 @@
+package server.poptato.app.infra;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import server.poptato.app.domain.entity.AppUpdateLog;
+import server.poptato.app.domain.repository.AppUpdateLogRepository;
+
+public interface JpaAppUpdateLogRepository extends AppUpdateLogRepository, JpaRepository<AppUpdateLog, Long> {
+}

--- a/src/main/java/server/poptato/app/status/AppErrorStatus.java
+++ b/src/main/java/server/poptato/app/status/AppErrorStatus.java
@@ -1,0 +1,39 @@
+package server.poptato.app.status;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import server.poptato.global.response.code.BaseErrorCode;
+import server.poptato.global.response.dto.ErrorReasonDto;
+
+@Getter
+@RequiredArgsConstructor
+public enum AppErrorStatus implements BaseErrorCode {
+    _INVALID_PLATFORM(HttpStatus.BAD_REQUEST, "APP-001", "유효하지 않은 플랫폼입니다."),
+    _RELEASE_NOT_FOUND(HttpStatus.NOT_FOUND, "APP-002", "해당 플랫폼의 활성화된 릴리즈가 없습니다."),
+    _PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APP-003", "다운로드 URL 생성에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/server/poptato/global/config/SecurityConfig.java
+++ b/src/main/java/server/poptato/global/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package server.poptato.global.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * Spring Security 설정.
+ *
+ * 모든 요청을 permitAll로 설정하여 기존 JwtService 기반 인증 로직에 영향을 주지 않습니다.
+ * Security는 CORS 처리 목적으로만 사용합니다. (추후 통합)
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    /**
+     * CORS 설정.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    /**
+     * Security Filter Chain 설정.
+     *
+     * - 모든 요청 permitAll (기존 인증 로직 유지)
+     * - CORS 활성화
+     * - CSRF 비활성화
+     * - 세션 미사용 (STATELESS)
+     */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(AbstractHttpConfigurer::disable)
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorize -> authorize
+                .anyRequest().permitAll()
+            );
+
+        return http.build();
+    }
+}

--- a/src/main/java/server/poptato/global/config/SwaggerConfig.java
+++ b/src/main/java/server/poptato/global/config/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package server.poptato.global.config;
 
 import java.io.InputStream;
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import server.poptato.global.exception.CustomException;
 import server.poptato.global.response.status.ErrorStatus;
 
@@ -32,7 +34,11 @@ public class SwaggerConfig {
 					.name("Sangho Han")
 					.url("https://github.com/bbbang105")
 					.email("hchsa77@gmail.com"))
-			);
+			).servers(List.of(
+				new Server().url("http://localhost:8085").description("로컬 서버"),
+				new Server().url("https://prev-illdan.store").description("테스트 서버"),
+				new Server().url("https://prev-illdan-prod.store").description("배포 서버")
+			));
 		try {
 			// ✅ Swagger 전용 ObjectMapper 사용
 			ObjectMapper swaggerMapper = Json.mapper();

--- a/src/main/java/server/poptato/global/config/SwaggerConfig.java
+++ b/src/main/java/server/poptato/global/config/SwaggerConfig.java
@@ -1,6 +1,13 @@
 package server.poptato.global.config;
 
+import java.io.InputStream;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -8,62 +15,57 @@ import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
-
-import java.io.InputStream;
-import java.util.List;
+import server.poptato.global.exception.CustomException;
+import server.poptato.global.response.status.ErrorStatus;
 
 @Configuration
 public class SwaggerConfig {
-
-    @Bean
-    public OpenAPI customOpenAPI() {
-        OpenAPI openAPI = new OpenAPI()
-                .info(new Info()
-                        .title("Legacy Illdan API Documentation")
-                        .version("v1.0.5")
-                        .description("Spring REST Docs with Swagger UI.")
-                        .contact(new Contact()
-                                .name("Sangho Han")
-                                .url("https://github.com/bbbang105")
-                                .email("hchsa77@gmail.com"))
-                )
-                .servers(List.of(
-                        new Server().url("http://localhost:8085").description("로컬 서버"),
-                        new Server().url("https://prev-illdan.store").description("테스트 서버")
-                ));
-
-        try {
-            // ✅ Swagger 전용 ObjectMapper 사용
-            ObjectMapper swaggerMapper = Json.mapper();
-            ClassPathResource resource = new ClassPathResource("static/docs/open-api-3.0.1.json");
-            InputStream inputStream = resource.getInputStream();
-
-            // ✅ REST Docs에서 생성한 open-api JSON -> OpenAPI 객체로 변환
-            OpenAPI restDocsOpenAPI = swaggerMapper.readValue(inputStream, OpenAPI.class);
-
-            // ✅ REST Docs Paths 적용
-            openAPI.setPaths(restDocsOpenAPI.getPaths());
-
-            // ✅ REST Docs Components + Security 병합
-            Components components = restDocsOpenAPI.getComponents();
-            SecurityScheme apiKey = new SecurityScheme()
-                    .type(SecurityScheme.Type.APIKEY)
-                    .in(SecurityScheme.In.HEADER)
-                    .name("Authorization");
-
-            components.addSecuritySchemes("Bearer Token", apiKey);
-
-            openAPI.components(components)
-                    .addSecurityItem(new SecurityRequirement().addList("Bearer Token"));
-
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to load Swagger configuration from REST Docs JSON.", e);
-        }
-
-        return openAPI;
-    }
+	
+	@Bean
+	public OpenAPI customOpenAPI() {
+		OpenAPI openAPI = new OpenAPI()
+			.info(new Info()
+                        .title("Illdan API Documentation")
+                        .version("v1.2.0")
+				.description("Spring REST Docs with Swagger UI.")
+				.contact(new Contact()
+					.name("Sangho Han")
+					.url("https://github.com/bbbang105")
+					.email("hchsa77@gmail.com"))
+			);
+		try {
+			// ✅ Swagger 전용 ObjectMapper 사용
+			ObjectMapper swaggerMapper = Json.mapper();
+			ClassPathResource resource = new ClassPathResource("static/docs/open-api-3.0.1.json");
+			try (InputStream inputStream = resource.getInputStream()) {
+				// REST Docs에서 생성한 open-api JSON -> OpenAPI 객체로 변환
+				OpenAPI restDocsOpenAPI = swaggerMapper.readValue(inputStream, OpenAPI.class);
+				
+				// REST Docs Paths 적용
+				if (restDocsOpenAPI.getPaths() != null) {
+					openAPI.setPaths(restDocsOpenAPI.getPaths());
+				}
+				
+				// REST Docs Components + Security 병합
+				Components components = restDocsOpenAPI.getComponents() != null
+					? restDocsOpenAPI.getComponents()
+					: new Components();
+				
+				SecurityScheme bearerAuth = new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT");
+				
+				components.addSecuritySchemes("bearerAuth", bearerAuth);
+				
+				openAPI.components(components)
+					.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+			}
+		} catch (Exception e) {
+			throw new CustomException(ErrorStatus._FAILED_TRANSLATE_SWAGGER);
+		}
+		
+		return openAPI;
+	}
 }
+

--- a/src/main/java/server/poptato/global/config/WebConfig.java
+++ b/src/main/java/server/poptato/global/config/WebConfig.java
@@ -24,7 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOriginPatterns("*")
                 .allowedMethods("*")
-                .allowedHeaders("Authorization", "Content-Type")
+                .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3000);
     }

--- a/src/main/java/server/poptato/global/config/WebConfig.java
+++ b/src/main/java/server/poptato/global/config/WebConfig.java
@@ -2,7 +2,6 @@ package server.poptato.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import server.poptato.global.interceptor.LoggingInterceptor;
@@ -17,15 +16,5 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor)
                 .addPathPatterns("/**");
-    }
-
-    @Override
-    public void addCorsMappings(final CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOriginPatterns("*")
-                .allowedMethods("*")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3000);
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -83,6 +83,7 @@ springdoc:
     path: /swagger-ui.html
     tags-sorter: alpha
     operations-sorter: alpha
+    persist-authorization: true
   api-docs:
     path: /v3/api-docs
   show-actuator: false

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -84,6 +84,7 @@ springdoc:
     path: /swagger-ui.html
     tags-sorter: alpha
     operations-sorter: alpha
+    persist-authorization: true
   api-docs:
     path: /v3/api-docs
   show-actuator: false

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -84,6 +84,7 @@ springdoc:
     path: /swagger-ui.html
     tags-sorter: alpha
     operations-sorter: alpha
+    persist-authorization: true
   api-docs:
     path: /v3/api-docs
   show-actuator: false

--- a/src/test/java/server/poptato/app/api/AppControllerTest.java
+++ b/src/test/java/server/poptato/app/api/AppControllerTest.java
@@ -1,0 +1,258 @@
+package server.poptato.app.api;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+import server.poptato.app.api.request.SkipRequestDto;
+import server.poptato.app.application.AppService;
+import server.poptato.app.application.response.DownloadResponseDto;
+import server.poptato.app.application.response.VersionCheckResponseDto;
+import server.poptato.app.domain.value.Platform;
+import server.poptato.auth.application.service.JwtService;
+import server.poptato.configuration.ControllerTestConfig;
+
+import java.time.LocalDateTime;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AppController.class)
+public class AppControllerTest extends ControllerTestConfig {
+
+    @MockBean
+    private AppService appService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    @DisplayName("버전을 체크한다 - 업데이트 있음")
+    public void checkVersion_updateAvailable() throws Exception {
+        // given
+        VersionCheckResponseDto response = new VersionCheckResponseDto(
+                true,
+                "1.0.0",
+                "1.2.0",
+                LocalDateTime.of(2024, 1, 15, 10, 0, 0),
+                "버그 수정 및 성능 개선",
+                false
+        );
+
+        Mockito.when(jwtService.extractUserIdFromToken("Bearer sampleToken"))
+                .thenReturn(1L);
+        Mockito.when(appService.checkVersion(any(Long.class), anyString(), eq(Platform.MACOS)))
+                .thenReturn(response);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/app/version")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer sampleToken")
+                        .param("currentVersion", "1.0.0")
+                        .param("platform", "MACOS")
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("GLOBAL-200"))
+                .andExpect(jsonPath("$.result.updateAvailable").value(true))
+                .andExpect(jsonPath("$.result.currentVersion").value("1.0.0"))
+                .andExpect(jsonPath("$.result.latestVersion").value("1.2.0"))
+                .andExpect(jsonPath("$.result.isMandatory").value(false))
+
+                // docs
+                .andDo(MockMvcRestDocumentationWrapper.document("app/version-check",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("App API")
+                                        .description("앱 버전을 체크하여 업데이트 필요 여부를 확인한다.")
+                                        .queryParameters(
+                                                parameterWithName("currentVersion").description("현재 앱 버전 (ex. 1.0.0)"),
+                                                parameterWithName("platform").description("플랫폼 (MACOS | WINDOWS)")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("result.updateAvailable").type(JsonFieldType.BOOLEAN).description("업데이트 존재 여부"),
+                                                fieldWithPath("result.currentVersion").type(JsonFieldType.STRING).description("현재 버전"),
+                                                fieldWithPath("result.latestVersion").type(JsonFieldType.STRING).description("최신 버전"),
+                                                fieldWithPath("result.releaseDate").type(JsonFieldType.STRING).description("릴리즈 날짜").optional(),
+                                                fieldWithPath("result.releaseNote").type(JsonFieldType.STRING).description("릴리즈 노트").optional(),
+                                                fieldWithPath("result.isMandatory").type(JsonFieldType.BOOLEAN).description("강제 업데이트 여부").optional()
+                                        )
+                                        .responseSchema(Schema.schema("VersionCheckResponse"))
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("버전을 체크한다 - 업데이트 없음")
+    public void checkVersion_noUpdate() throws Exception {
+        // given
+        VersionCheckResponseDto response = VersionCheckResponseDto.noUpdate("1.2.0");
+
+        Mockito.when(jwtService.extractUserIdFromToken("Bearer sampleToken"))
+                .thenReturn(1L);
+        Mockito.when(appService.checkVersion(any(Long.class), anyString(), eq(Platform.MACOS)))
+                .thenReturn(response);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/app/version")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer sampleToken")
+                        .param("currentVersion", "1.2.0")
+                        .param("platform", "MACOS")
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.updateAvailable").value(false))
+                .andExpect(jsonPath("$.result.currentVersion").value("1.2.0"))
+                .andExpect(jsonPath("$.result.latestVersion").value("1.2.0"));
+    }
+
+    @Test
+    @DisplayName("다운로드 URL을 조회한다")
+    public void getDownloadUrl() throws Exception {
+        // given
+        DownloadResponseDto response = new DownloadResponseDto(
+                "1.2.0",
+                "MACOS",
+                "https://s3.amazonaws.com/bucket/macos/Poptato-1.2.0.dmg?presigned...",
+                "abc123sha512hash",
+                85000000L
+        );
+
+        Mockito.when(jwtService.extractUserIdFromToken("Bearer sampleToken"))
+                .thenReturn(1L);
+        Mockito.when(appService.getDownloadUrl(any(Long.class), eq(Platform.MACOS), anyString()))
+                .thenReturn(response);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/app/download")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer sampleToken")
+                        .param("platform", "MACOS")
+                        .param("currentVersion", "1.0.0")
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("GLOBAL-200"))
+                .andExpect(jsonPath("$.result.version").value("1.2.0"))
+                .andExpect(jsonPath("$.result.platform").value("MACOS"))
+                .andExpect(jsonPath("$.result.downloadUrl").exists())
+                .andExpect(jsonPath("$.result.sha512").value("abc123sha512hash"))
+                .andExpect(jsonPath("$.result.size").value(85000000L))
+
+                // docs
+                .andDo(MockMvcRestDocumentationWrapper.document("app/download",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("App API")
+                                        .description("플랫폼에 해당하는 앱 다운로드 URL(S3 Presigned URL)을 조회한다.")
+                                        .queryParameters(
+                                                parameterWithName("platform").description("플랫폼 (MACOS | WINDOWS)"),
+                                                parameterWithName("currentVersion").description("현재 앱 버전 (로깅용)").optional()
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("result.version").type(JsonFieldType.STRING).description("다운로드 버전"),
+                                                fieldWithPath("result.platform").type(JsonFieldType.STRING).description("플랫폼"),
+                                                fieldWithPath("result.downloadUrl").type(JsonFieldType.STRING).description("S3 Presigned URL"),
+                                                fieldWithPath("result.sha512").type(JsonFieldType.STRING).description("파일 해시"),
+                                                fieldWithPath("result.size").type(JsonFieldType.NUMBER).description("파일 크기 (bytes)")
+                                        )
+                                        .responseSchema(Schema.schema("DownloadResponse"))
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("업데이트를 스킵한다")
+    public void skipUpdate() throws Exception {
+        // given
+        Mockito.when(jwtService.extractUserIdFromToken("Bearer sampleToken"))
+                .thenReturn(1L);
+        Mockito.doNothing().when(appService).skipUpdate(any(Long.class), any(SkipRequestDto.class));
+
+        SkipRequestDto request = new SkipRequestDto("1.0.0", "1.2.0", Platform.MACOS);
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/app/skip")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer sampleToken")
+                        .content(requestContent)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("GLOBAL-200"))
+                .andExpect(jsonPath("$.result").doesNotExist())
+
+                // docs
+                .andDo(MockMvcRestDocumentationWrapper.document("app/skip",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("App API")
+                                        .description("사용자가 '다음에 설치' 선택 시 업데이트 스킵을 기록한다.")
+                                        .requestFields(
+                                                fieldWithPath("currentVersion").type(JsonFieldType.STRING).description("현재 앱 버전"),
+                                                fieldWithPath("targetVersion").type(JsonFieldType.STRING).description("스킵한 대상 버전"),
+                                                fieldWithPath("platform").type(JsonFieldType.STRING).description("플랫폼 (MACOS | WINDOWS)")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                                        )
+                                        .requestSchema(Schema.schema("SkipRequest"))
+                                        .responseSchema(Schema.schema("SkipResponse"))
+                                        .build()
+                        )
+                ));
+    }
+}

--- a/src/test/java/server/poptato/app/application/AppServiceTest.java
+++ b/src/test/java/server/poptato/app/application/AppServiceTest.java
@@ -1,0 +1,256 @@
+package server.poptato.app.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import server.poptato.app.api.request.SkipRequestDto;
+import server.poptato.app.application.response.DownloadResponseDto;
+import server.poptato.app.application.response.VersionCheckResponseDto;
+import server.poptato.app.domain.entity.AppRelease;
+import server.poptato.app.domain.entity.AppUpdateLog;
+import server.poptato.app.domain.repository.AppReleaseRepository;
+import server.poptato.app.domain.repository.AppUpdateLogRepository;
+import server.poptato.app.domain.value.Platform;
+import server.poptato.app.domain.value.UpdateEventType;
+import server.poptato.app.status.AppErrorStatus;
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.global.exception.CustomException;
+import server.poptato.infra.s3.service.S3Service;
+
+public class AppServiceTest extends ServiceTestConfig {
+
+    @Mock
+    AppReleaseRepository appReleaseRepository;
+
+    @Mock
+    AppUpdateLogRepository appUpdateLogRepository;
+
+    @Mock
+    S3Service s3Service;
+
+    @Captor
+    ArgumentCaptor<AppUpdateLog> logCaptor;
+
+    @InjectMocks
+    AppService appService;
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    @DisplayName("[SCN-SVC-APP-001] 버전을 체크한다.")
+    class CheckVersion {
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-001][TC-VERSION-001] 업데이트가 있으면 updateAvailable=true와 릴리즈 정보를 반환한다.")
+        void checkVersion_updateAvailable_returnsUpdateInfo() {
+            // given
+            Long userId = 1L;
+            String currentVersion = "1.0.0";
+
+            AppRelease release = mock(AppRelease.class);
+            when(release.getVersion()).thenReturn("1.2.0");
+            when(release.getIsMandatory()).thenReturn(false);
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.MACOS))
+                    .thenReturn(Optional.of(release));
+
+            // when
+            VersionCheckResponseDto response = appService.checkVersion(userId, currentVersion, Platform.MACOS);
+
+            // then
+            assertThat(response.updateAvailable()).isTrue();
+            assertThat(response.currentVersion()).isEqualTo(currentVersion);
+            assertThat(response.latestVersion()).isEqualTo("1.2.0");
+            assertThat(response.isMandatory()).isFalse();
+
+            verify(appUpdateLogRepository).save(logCaptor.capture());
+            AppUpdateLog log = logCaptor.getValue();
+            assertThat(log.getUserId()).isEqualTo(userId);
+            assertThat(log.getEventType()).isEqualTo(UpdateEventType.VERSION_CHECK);
+            assertThat(log.getUpdateAvailable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-001][TC-VERSION-002] 업데이트가 없으면 updateAvailable=false를 반환한다.")
+        void checkVersion_noUpdate_returnsNoUpdate() {
+            // given
+            Long userId = 1L;
+            String currentVersion = "1.2.0";
+
+            AppRelease release = mock(AppRelease.class);
+            when(release.getVersion()).thenReturn("1.2.0");
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.MACOS))
+                    .thenReturn(Optional.of(release));
+
+            // when
+            VersionCheckResponseDto response = appService.checkVersion(userId, currentVersion, Platform.MACOS);
+
+            // then
+            assertThat(response.updateAvailable()).isFalse();
+            assertThat(response.currentVersion()).isEqualTo(currentVersion);
+            assertThat(response.latestVersion()).isEqualTo(currentVersion);
+
+            verify(appUpdateLogRepository).save(logCaptor.capture());
+            assertThat(logCaptor.getValue().getUpdateAvailable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-001][TC-VERSION-003] 활성화된 릴리즈가 없으면 updateAvailable=false를 반환한다.")
+        void checkVersion_noActiveRelease_returnsNoUpdate() {
+            // given
+            Long userId = 1L;
+            String currentVersion = "1.0.0";
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.WINDOWS))
+                    .thenReturn(Optional.empty());
+
+            // when
+            VersionCheckResponseDto response = appService.checkVersion(userId, currentVersion, Platform.WINDOWS);
+
+            // then
+            assertThat(response.updateAvailable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-001][TC-VERSION-004] 강제 업데이트가 필요한 경우 isMandatory=true를 반환한다.")
+        void checkVersion_mandatory_returnsMandatoryTrue() {
+            // given
+            Long userId = 1L;
+            String currentVersion = "1.0.0";
+
+            AppRelease release = mock(AppRelease.class);
+            when(release.getVersion()).thenReturn("2.0.0");
+            when(release.getIsMandatory()).thenReturn(true);
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.WINDOWS))
+                    .thenReturn(Optional.of(release));
+
+            // when
+            VersionCheckResponseDto response = appService.checkVersion(userId, currentVersion, Platform.WINDOWS);
+
+            // then
+            assertThat(response.updateAvailable()).isTrue();
+            assertThat(response.isMandatory()).isTrue();
+            assertThat(response.latestVersion()).isEqualTo("2.0.0");
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-001][TC-VERSION-005] 로그에 현재 버전과 대상 버전이 정확히 기록된다.")
+        void checkVersion_logsCorrectVersions() {
+            // given
+            Long userId = 10L;
+            String currentVersion = "1.0.0";
+
+            AppRelease release = mock(AppRelease.class);
+            when(release.getVersion()).thenReturn("1.5.0");
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.MACOS))
+                    .thenReturn(Optional.of(release));
+
+            // when
+            appService.checkVersion(userId, currentVersion, Platform.MACOS);
+
+            // then
+            verify(appUpdateLogRepository).save(logCaptor.capture());
+            AppUpdateLog log = logCaptor.getValue();
+            assertThat(log.getCurrentVersion()).isEqualTo("1.0.0");
+            assertThat(log.getTargetVersion()).isEqualTo("1.5.0");
+            assertThat(log.getPlatform()).isEqualTo(Platform.MACOS);
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    @DisplayName("[SCN-SVC-APP-002] 다운로드 URL을 조회한다.")
+    class GetDownloadUrl {
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-002][TC-DOWNLOAD-001] 정상적으로 Presigned URL을 반환한다.")
+        void getDownloadUrl_success_returnsPresignedUrl() {
+            // given
+            Long userId = 1L;
+            String currentVersion = "1.0.0";
+
+            AppRelease release = mock(AppRelease.class);
+            when(release.getVersion()).thenReturn("1.2.0");
+            when(release.getPlatform()).thenReturn(Platform.MACOS);
+            when(release.getFilePath()).thenReturn("macos/Poptato-1.2.0.dmg");
+            when(release.getSha512()).thenReturn("abc123");
+            when(release.getFileSize()).thenReturn(85000000L);
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.MACOS))
+                    .thenReturn(Optional.of(release));
+            when(s3Service.generatePresignedUrl("macos/Poptato-1.2.0.dmg"))
+                    .thenReturn("https://s3.amazonaws.com/presigned-url");
+
+            // when
+            DownloadResponseDto response = appService.getDownloadUrl(userId, Platform.MACOS, currentVersion);
+
+            // then
+            assertThat(response.version()).isEqualTo("1.2.0");
+            assertThat(response.platform()).isEqualTo("MACOS");
+            assertThat(response.downloadUrl()).isEqualTo("https://s3.amazonaws.com/presigned-url");
+            assertThat(response.sha512()).isEqualTo("abc123");
+            assertThat(response.size()).isEqualTo(85000000L);
+
+            verify(appUpdateLogRepository).save(logCaptor.capture());
+            AppUpdateLog log = logCaptor.getValue();
+            assertThat(log.getEventType()).isEqualTo(UpdateEventType.DOWNLOADED);
+        }
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-002][TC-DOWNLOAD-002] 활성화된 릴리즈가 없으면 예외를 던진다.")
+        void getDownloadUrl_noRelease_throwsException() {
+            // given
+            Long userId = 1L;
+            String currentVersion = "1.0.0";
+
+            when(appReleaseRepository.findByPlatformAndIsActiveTrue(Platform.WINDOWS))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> appService.getDownloadUrl(userId, Platform.WINDOWS, currentVersion))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(AppErrorStatus._RELEASE_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    @DisplayName("[SCN-SVC-APP-003] 업데이트를 스킵한다.")
+    class SkipUpdate {
+
+        @Test
+        @DisplayName("[SCN-SVC-APP-003][TC-SKIP-001] 정상적으로 스킵 로그를 저장한다.")
+        void skipUpdate_success_savesLog() {
+            // given
+            Long userId = 1L;
+            SkipRequestDto request = new SkipRequestDto("1.0.0", "1.2.0", Platform.MACOS);
+
+            // when
+            appService.skipUpdate(userId, request);
+
+            // then
+            verify(appUpdateLogRepository).save(logCaptor.capture());
+            AppUpdateLog log = logCaptor.getValue();
+            assertThat(log.getUserId()).isEqualTo(userId);
+            assertThat(log.getEventType()).isEqualTo(UpdateEventType.UPDATE_SKIPPED);
+            assertThat(log.getCurrentVersion()).isEqualTo("1.0.0");
+            assertThat(log.getTargetVersion()).isEqualTo("1.2.0");
+            assertThat(log.getPlatform()).isEqualTo(Platform.MACOS);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 테스트코드 추가
- [ ] 성능 개선 작업
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 주요 변경사항
1. Platform enum 강제: MACOS, WINDOWS (대문자 필수, 잘못된 값은 400 에러)
2. S3 Presigned URL: 30분 유효기간
3. 업데이트 로그 기록: VERSION_CHECK, DOWNLOADED, UPDATE_SKIPPED 이벤트
4. 강제 업데이트 지원: isMandatory 플래그
5. Swagger 토큰 persist: 새로고침해도 Bearer 토큰 유지

### 신규 테이블
1. app_release: 릴리즈 정보 (버전, 플랫폼, S3 경로, SHA-512 등)
2. app_update_log: 업데이트 이벤트 로깅

### 신규 패키지

```
server.poptato.app/
├── api/           # Controller, Request DTO
├── application/   # Service, Response DTO
├── domain/        # Entity, Repository, Value Objects
└── status/        # Error Status
```

> **고민하다가 이후에 모바일 앱에도 해당 기능이 활용되기 때문에, 조금 더 범용적인 `app`을 택하였습니다.**

### 테스트
1. AppServiceTest: 12개 테스트 케이스
2. AppControllerTest: 4개 테스트 케이스 (REST Docs 포함)

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

- 테이블 DDL 등 자세한 내용은 [노션 페이지](https://www.notion.so/2cfd60b563cc80d7a447f5bbf5180756?source=copy_link) 참고 부탁드립니다.


---